### PR TITLE
Fix color not applied in spawn_physics_blueprint_actor

### DIFF
--- a/Python/unreal_mcp_server_advanced.py
+++ b/Python/unreal_mcp_server_advanced.py
@@ -1242,8 +1242,7 @@ def spawn_physics_blueprint_actor (
                     logger.warning(f"Failed to set color {color} for {bp_name}: {color_result.get('message', 'Unknown error')}")
 
         compile_blueprint(bp_name)
-        result = spawn_blueprint_actor(bp_name, name, location)
-        
+
         # Spawn the blueprint actor using helper function
         unreal = get_unreal_connection()
         result = spawn_blueprint_actor(unreal, bp_name, name, location)
@@ -1252,6 +1251,14 @@ def spawn_physics_blueprint_actor (
         if result.get("success", False):
             spawned_name = result.get("result", {}).get("name", name)
             set_actor_transform(spawned_name, scale=scale)
+
+            # Apply color to the spawned actor instance
+            # Blueprint material colors may not persist through compile+spawn,
+            # so we also apply the color directly on the spawned actor
+            if color is not None:
+                apply_result = set_mesh_material_color(spawned_name, "Mesh", color)
+                if not apply_result.get("success", False):
+                    logger.warning(f"Failed to apply color to spawned actor {spawned_name}: {apply_result.get('message', 'Unknown error')}")
 
         return result
     except Exception as e:


### PR DESCRIPTION
## Summary
- Remove duplicate broken `spawn_blueprint_actor` call that passed wrong arguments (blueprint name as connection object)
- Apply color directly to the spawned actor instance after creation, since blueprint material colors may not persist through compile and spawn

## Test plan
- [ ] Call `spawn_physics_blueprint_actor` with a color parameter (e.g., `color=[1.0, 0.0, 0.0]`) and verify the spawned actor appears red
- [ ] Call without a color parameter and verify default behavior is unchanged
- [ ] Test with 3-value `[R, G, B]` and 4-value `[R, G, B, A]` color formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)