### PR TITLE
fix(blueprint): resolve UClass lookups so non-trivial parent_class & component_type work

### DIFF
--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPBlueprintCommands.cpp
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPBlueprintCommands.cpp
@@ -132,48 +132,55 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintCommands::HandleCreateBlueprint(c
     // Default to Actor if no parent class specified
     UClass* SelectedParentClass = AActor::StaticClass();
     
-    // Try to find the specified parent class
+    // Try to find the specified parent class.
+    //
+    // UE runtime class names do NOT carry the C++ A/U prefix — `/Script/Engine.Character`
+    // is the path, NOT `/Script/Engine.ACharacter`. Try the bare name first, then the
+    // A-prefixed name as a courtesy, then a global FindFirstObject fallback.
     if (!ParentClass.IsEmpty())
     {
-        FString ClassName = ParentClass;
-        if (!ClassName.StartsWith(TEXT("A")))
-        {
-            ClassName = TEXT("A") + ClassName;
-        }
-        
-        // First try direct StaticClass lookup for common classes
         UClass* FoundClass = nullptr;
-        if (ClassName == TEXT("APawn"))
+        const FString BareName = ParentClass.StartsWith(TEXT("A")) && ParentClass.Len() > 1 && FChar::IsUpper(ParentClass[1])
+            ? ParentClass.RightChop(1) // strip leading 'A' if user passed "ACharacter"
+            : ParentClass;
+        const FString PrefixedName = TEXT("A") + BareName;
+
+        // Hardcoded fast-paths for the two we use most
+        if (BareName == TEXT("Pawn"))      FoundClass = APawn::StaticClass();
+        else if (BareName == TEXT("Actor")) FoundClass = AActor::StaticClass();
+
+        // Path lookups: try /Script/Engine + /Script/Game with both bare and prefixed
+        const TArray<FString> Candidates = {
+            FString::Printf(TEXT("/Script/Engine.%s"), *BareName),
+            FString::Printf(TEXT("/Script/Engine.%s"), *PrefixedName),
+            FString::Printf(TEXT("/Script/Game.%s"),   *BareName),
+            FString::Printf(TEXT("/Script/Game.%s"),   *PrefixedName),
+        };
+        for (const FString& Path : Candidates)
         {
-            FoundClass = APawn::StaticClass();
+            if (FoundClass) break;
+            FoundClass = LoadClass<AActor>(nullptr, *Path);
         }
-        else if (ClassName == TEXT("AActor"))
+
+        // Last resort: scan all loaded classes by name (catches plugin/module classes)
+        if (!FoundClass)
         {
-            FoundClass = AActor::StaticClass();
-        }
-        else
-        {
-            // Try loading the class using LoadClass which is more reliable than FindObject
-            const FString ClassPath = FString::Printf(TEXT("/Script/Engine.%s"), *ClassName);
-            FoundClass = LoadClass<AActor>(nullptr, *ClassPath);
-            
-            if (!FoundClass)
+            FoundClass = FindFirstObjectSafe<UClass>(*BareName, EFindFirstObjectOptions::None);
+            if (FoundClass && !FoundClass->IsChildOf(AActor::StaticClass()))
             {
-                // Try alternate paths if not found
-                const FString GameClassPath = FString::Printf(TEXT("/Script/Game.%s"), *ClassName);
-                FoundClass = LoadClass<AActor>(nullptr, *GameClassPath);
+                FoundClass = nullptr; // must be Actor-derived for a Blueprint parent
             }
         }
 
         if (FoundClass)
         {
             SelectedParentClass = FoundClass;
-            UE_LOG(LogTemp, Log, TEXT("Successfully set parent class to '%s'"), *ClassName);
+            UE_LOG(LogTemp, Log, TEXT("Set parent class to '%s' (resolved from input '%s')"), *FoundClass->GetName(), *ParentClass);
         }
         else
         {
-            UE_LOG(LogTemp, Warning, TEXT("Could not find specified parent class '%s' at paths: /Script/Engine.%s or /Script/Game.%s, defaulting to AActor"), 
-                *ClassName, *ClassName, *ClassName);
+            UE_LOG(LogTemp, Warning, TEXT("Could not find parent class '%s' (tried bare/prefixed in /Script/Engine, /Script/Game, and global scan), defaulting to AActor"),
+                *ParentClass);
         }
     }
     
@@ -228,31 +235,42 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintCommands::HandleAddComponentToBlu
         return FEpicUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Blueprint not found: %s"), *BlueprintName));
     }
 
-    // Create the component - dynamically find the component class by name
+    // Create the component - dynamically find the component class by name.
+    //
+    // FindObject<UClass>(nullptr, X) only resolves bare names if they live in the
+    // transient package. Engine components live in /Script/Engine.*, so a bare name
+    // search misses them. Use FindFirstObjectSafe (global, name-only) plus path
+    // candidates to handle every common form: "StaticMeshComponent",
+    // "StaticMesh", "UStaticMeshComponent", or "/Script/Engine.StaticMeshComponent".
     UClass* ComponentClass = nullptr;
 
-    // Try to find the class with exact name first
-    ComponentClass = FindObject<UClass>(nullptr, *ComponentType);
-    
-    // If not found, try with "Component" suffix
-    if (!ComponentClass && !ComponentType.EndsWith(TEXT("Component")))
+    auto TryResolve = [&](const FString& Name) -> UClass*
     {
-        FString ComponentTypeWithSuffix = ComponentType + TEXT("Component");
-        ComponentClass = FindObject<UClass>(nullptr, *ComponentTypeWithSuffix);
-    }
-    
-    // If still not found, try with "U" prefix
-    if (!ComponentClass && !ComponentType.StartsWith(TEXT("U")))
-    {
-        FString ComponentTypeWithPrefix = TEXT("U") + ComponentType;
-        ComponentClass = FindObject<UClass>(nullptr, *ComponentTypeWithPrefix);
-        
-        // Try with both prefix and suffix
-        if (!ComponentClass && !ComponentType.EndsWith(TEXT("Component")))
+        if (Name.IsEmpty()) return nullptr;
+        // Full path? Let the engine resolve it.
+        if (Name.Contains(TEXT(".")))
         {
-            FString ComponentTypeWithBoth = TEXT("U") + ComponentType + TEXT("Component");
-            ComponentClass = FindObject<UClass>(nullptr, *ComponentTypeWithBoth);
+            if (UClass* C = LoadObject<UClass>(nullptr, *Name)) return C;
         }
+        // Global name scan across all loaded classes.
+        if (UClass* C = FindFirstObjectSafe<UClass>(*Name, EFindFirstObjectOptions::None)) return C;
+        // Path lookup in /Script/Engine — handles cold-loaded engine modules.
+        if (UClass* C = LoadObject<UClass>(nullptr, *FString::Printf(TEXT("/Script/Engine.%s"), *Name))) return C;
+        return nullptr;
+    };
+
+    // Strip leading 'U' prefix if the caller wrote it C++-style.
+    FString BareType = ComponentType.StartsWith(TEXT("U")) && ComponentType.Len() > 1 && FChar::IsUpper(ComponentType[1])
+        ? ComponentType.RightChop(1)
+        : ComponentType;
+
+    // Try in priority order: exact (preserves full paths), bare-stripped,
+    // then with "Component" suffix.
+    ComponentClass = TryResolve(ComponentType);
+    if (!ComponentClass) ComponentClass = TryResolve(BareType);
+    if (!ComponentClass && !BareType.EndsWith(TEXT("Component")))
+    {
+        ComponentClass = TryResolve(BareType + TEXT("Component"));
     }
     
     // Verify that the class is a valid component type

--- a/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPBlueprintCommands.cpp
+++ b/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPBlueprintCommands.cpp
@@ -132,48 +132,55 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintCommands::HandleCreateBlueprint(c
     // Default to Actor if no parent class specified
     UClass* SelectedParentClass = AActor::StaticClass();
     
-    // Try to find the specified parent class
+    // Try to find the specified parent class.
+    //
+    // UE runtime class names do NOT carry the C++ A/U prefix — `/Script/Engine.Character`
+    // is the path, NOT `/Script/Engine.ACharacter`. Try the bare name first, then the
+    // A-prefixed name as a courtesy, then a global FindFirstObject fallback.
     if (!ParentClass.IsEmpty())
     {
-        FString ClassName = ParentClass;
-        if (!ClassName.StartsWith(TEXT("A")))
-        {
-            ClassName = TEXT("A") + ClassName;
-        }
-        
-        // First try direct StaticClass lookup for common classes
         UClass* FoundClass = nullptr;
-        if (ClassName == TEXT("APawn"))
+        const FString BareName = ParentClass.StartsWith(TEXT("A")) && ParentClass.Len() > 1 && FChar::IsUpper(ParentClass[1])
+            ? ParentClass.RightChop(1) // strip leading 'A' if user passed "ACharacter"
+            : ParentClass;
+        const FString PrefixedName = TEXT("A") + BareName;
+
+        // Hardcoded fast-paths for the two we use most
+        if (BareName == TEXT("Pawn"))      FoundClass = APawn::StaticClass();
+        else if (BareName == TEXT("Actor")) FoundClass = AActor::StaticClass();
+
+        // Path lookups: try /Script/Engine + /Script/Game with both bare and prefixed
+        const TArray<FString> Candidates = {
+            FString::Printf(TEXT("/Script/Engine.%s"), *BareName),
+            FString::Printf(TEXT("/Script/Engine.%s"), *PrefixedName),
+            FString::Printf(TEXT("/Script/Game.%s"),   *BareName),
+            FString::Printf(TEXT("/Script/Game.%s"),   *PrefixedName),
+        };
+        for (const FString& Path : Candidates)
         {
-            FoundClass = APawn::StaticClass();
+            if (FoundClass) break;
+            FoundClass = LoadClass<AActor>(nullptr, *Path);
         }
-        else if (ClassName == TEXT("AActor"))
+
+        // Last resort: scan all loaded classes by name (catches plugin/module classes)
+        if (!FoundClass)
         {
-            FoundClass = AActor::StaticClass();
-        }
-        else
-        {
-            // Try loading the class using LoadClass which is more reliable than FindObject
-            const FString ClassPath = FString::Printf(TEXT("/Script/Engine.%s"), *ClassName);
-            FoundClass = LoadClass<AActor>(nullptr, *ClassPath);
-            
-            if (!FoundClass)
+            FoundClass = FindFirstObjectSafe<UClass>(*BareName, EFindFirstObjectOptions::None);
+            if (FoundClass && !FoundClass->IsChildOf(AActor::StaticClass()))
             {
-                // Try alternate paths if not found
-                const FString GameClassPath = FString::Printf(TEXT("/Script/Game.%s"), *ClassName);
-                FoundClass = LoadClass<AActor>(nullptr, *GameClassPath);
+                FoundClass = nullptr; // must be Actor-derived for a Blueprint parent
             }
         }
 
         if (FoundClass)
         {
             SelectedParentClass = FoundClass;
-            UE_LOG(LogTemp, Log, TEXT("Successfully set parent class to '%s'"), *ClassName);
+            UE_LOG(LogTemp, Log, TEXT("Set parent class to '%s' (resolved from input '%s')"), *FoundClass->GetName(), *ParentClass);
         }
         else
         {
-            UE_LOG(LogTemp, Warning, TEXT("Could not find specified parent class '%s' at paths: /Script/Engine.%s or /Script/Game.%s, defaulting to AActor"), 
-                *ClassName, *ClassName, *ClassName);
+            UE_LOG(LogTemp, Warning, TEXT("Could not find parent class '%s' (tried bare/prefixed in /Script/Engine, /Script/Game, and global scan), defaulting to AActor"),
+                *ParentClass);
         }
     }
     
@@ -228,31 +235,42 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintCommands::HandleAddComponentToBlu
         return FEpicUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Blueprint not found: %s"), *BlueprintName));
     }
 
-    // Create the component - dynamically find the component class by name
+    // Create the component - dynamically find the component class by name.
+    //
+    // FindObject<UClass>(nullptr, X) only resolves bare names if they live in the
+    // transient package. Engine components live in /Script/Engine.*, so a bare name
+    // search misses them. Use FindFirstObjectSafe (global, name-only) plus path
+    // candidates to handle every common form: "StaticMeshComponent",
+    // "StaticMesh", "UStaticMeshComponent", or "/Script/Engine.StaticMeshComponent".
     UClass* ComponentClass = nullptr;
 
-    // Try to find the class with exact name first
-    ComponentClass = FindObject<UClass>(nullptr, *ComponentType);
-    
-    // If not found, try with "Component" suffix
-    if (!ComponentClass && !ComponentType.EndsWith(TEXT("Component")))
+    auto TryResolve = [&](const FString& Name) -> UClass*
     {
-        FString ComponentTypeWithSuffix = ComponentType + TEXT("Component");
-        ComponentClass = FindObject<UClass>(nullptr, *ComponentTypeWithSuffix);
-    }
-    
-    // If still not found, try with "U" prefix
-    if (!ComponentClass && !ComponentType.StartsWith(TEXT("U")))
-    {
-        FString ComponentTypeWithPrefix = TEXT("U") + ComponentType;
-        ComponentClass = FindObject<UClass>(nullptr, *ComponentTypeWithPrefix);
-        
-        // Try with both prefix and suffix
-        if (!ComponentClass && !ComponentType.EndsWith(TEXT("Component")))
+        if (Name.IsEmpty()) return nullptr;
+        // Full path? Let the engine resolve it.
+        if (Name.Contains(TEXT(".")))
         {
-            FString ComponentTypeWithBoth = TEXT("U") + ComponentType + TEXT("Component");
-            ComponentClass = FindObject<UClass>(nullptr, *ComponentTypeWithBoth);
+            if (UClass* C = LoadObject<UClass>(nullptr, *Name)) return C;
         }
+        // Global name scan across all loaded classes.
+        if (UClass* C = FindFirstObjectSafe<UClass>(*Name, EFindFirstObjectOptions::None)) return C;
+        // Path lookup in /Script/Engine — handles cold-loaded engine modules.
+        if (UClass* C = LoadObject<UClass>(nullptr, *FString::Printf(TEXT("/Script/Engine.%s"), *Name))) return C;
+        return nullptr;
+    };
+
+    // Strip leading 'U' prefix if the caller wrote it C++-style.
+    FString BareType = ComponentType.StartsWith(TEXT("U")) && ComponentType.Len() > 1 && FChar::IsUpper(ComponentType[1])
+        ? ComponentType.RightChop(1)
+        : ComponentType;
+
+    // Try in priority order: exact (preserves full paths), bare-stripped,
+    // then with "Component" suffix.
+    ComponentClass = TryResolve(ComponentType);
+    if (!ComponentClass) ComponentClass = TryResolve(BareType);
+    if (!ComponentClass && !BareType.EndsWith(TEXT("Component")))
+    {
+        ComponentClass = TryResolve(BareType + TEXT("Component"));
     }
     
     // Verify that the class is a valid component type


### PR DESCRIPTION
## Summary

Two longstanding bugs in `HandleCreateBlueprint` and `HandleAddComponentToBlueprint` (in `EpicUnrealMCPBlueprintCommands.cpp`) made the plugin silently incorrect for nearly every input:

### Bug 1 — `parent_class` was effectively limited to `Pawn` / `Actor`

The handler prepends an `A` to the input then looks up `/Script/Engine.A<Name>`. UE runtime `UClass` names do **not** carry the C++ `A`/`U` prefix — the actual path is `/Script/Engine.Character`, not `/Script/Engine.ACharacter`. So `parent_class="Character"` (and anything not in the hardcoded short-circuit) silently fell back to `AActor`, with a warning logged about `/Script/Engine.A<Name>` not existing.

### Bug 2 — `component_type` rejected every standard engine component

```cpp
ComponentClass = FindObject<UClass>(nullptr, *ComponentType);
```

`FindObject<UClass>(nullptr, BareName)` only searches the transient package. Engine components live in `/Script/Engine.*`, so `StaticMeshComponent`, `CameraComponent`, `PointLightComponent`, `BoxComponent` all returned `Unknown component type`. The existing `Component`-suffix and `U`-prefix retries didn't help because the underlying lookup was still scoped wrong.

## Fix

- **Parent class:** drop the `A`-prefix logic. Try `/Script/Engine.<Bare>`, `/Script/Engine.A<Bare>`, and the `/Script/Game.*` variants, then fall back to `FindFirstObjectSafe<UClass>` (UE 5.1+) for plugin/module-defined classes. Validate that the resolved class is `Actor`-derived.
- **Component type:** replace `FindObject(nullptr, ...)` with `FindFirstObjectSafe<UClass>` plus a full-path fallback via `LoadObject<UClass>`. Bare names like `Camera`, `StaticMesh`, `PointLight`, `Box`, full paths like `/Script/Engine.SkeletalMeshComponent`, and C++-prefixed `UCameraComponent` all resolve. Strips a leading `U` if the caller wrote it C++-style.

Both copies of the file (`UnrealMCP/Source/...` and `FlopperamUnrealMCP/Plugins/UnrealMCP/Source/...`) are kept in sync as before.

## Verification

Tested on UE 5.7 against a `Character`-derived blueprint:

- `create_blueprint(name="BP_FPSCharacter", parent_class="Character")` → parent now correctly `Character` (was `Actor`)
- `add_component_to_blueprint(component_type="CameraComponent", ...)` → ✅ (was `Unknown component type`)
- `add_component_to_blueprint(component_type="StaticMeshComponent", ...)` → ✅
- `add_component_to_blueprint(component_type="PointLightComponent", ...)` → ✅
- `add_component_to_blueprint(component_type="Box", ...)` → ✅ (resolves to `BoxComponent`)
- Compile clean, transform/properties applied correctly.

No changes outside the two `EpicUnrealMCPBlueprintCommands.cpp` copies.