### PR TITLE
Add Blueprint graph authoring commands

### DIFF
--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/BPConnector.cpp
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/BPConnector.cpp
@@ -8,6 +8,67 @@
 #include "Kismet2/KismetEditorUtilities.h"
 #include "EditorAssetLibrary.h"
 
+namespace
+{
+UBlueprint* LoadConnectorBlueprint(const FString& BlueprintName)
+{
+    FString BlueprintPath = BlueprintName;
+    if (!BlueprintPath.StartsWith(TEXT("/")))
+    {
+        BlueprintPath = TEXT("/Game/Blueprints/") + BlueprintPath;
+    }
+
+    if (!BlueprintPath.Contains(TEXT(".")))
+    {
+        BlueprintPath += TEXT(".") + FPaths::GetBaseFilename(BlueprintPath);
+    }
+
+    if (UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *BlueprintPath))
+    {
+        return Blueprint;
+    }
+
+    if (UEditorAssetLibrary::DoesAssetExist(BlueprintPath))
+    {
+        return Cast<UBlueprint>(UEditorAssetLibrary::LoadAsset(BlueprintPath));
+    }
+
+    return nullptr;
+}
+
+UEdGraph* FindConnectorGraph(UBlueprint* Blueprint, const FString& FunctionName)
+{
+    if (!Blueprint)
+    {
+        return nullptr;
+    }
+
+    if (!FunctionName.IsEmpty())
+    {
+        for (UEdGraph* FuncGraph : Blueprint->FunctionGraphs)
+        {
+            if (FuncGraph && (FuncGraph->GetFName().ToString() == FunctionName ||
+                              (FuncGraph->GetOuter() && FuncGraph->GetOuter()->GetFName().ToString() == FunctionName)))
+            {
+                return FuncGraph;
+            }
+        }
+
+        for (UEdGraph* FuncGraph : Blueprint->FunctionGraphs)
+        {
+            if (FuncGraph && FuncGraph->GetFName().ToString().Contains(FunctionName))
+            {
+                return FuncGraph;
+            }
+        }
+
+        return nullptr;
+    }
+
+    return Blueprint->UbergraphPages.Num() > 0 ? Blueprint->UbergraphPages[0] : nullptr;
+}
+}
+
 TSharedPtr<FJsonObject> FBPConnector::ConnectNodes(const TSharedPtr<FJsonObject>& Params)
 {
     TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
@@ -23,34 +84,7 @@ TSharedPtr<FJsonObject> FBPConnector::ConnectNodes(const TSharedPtr<FJsonObject>
     Params->TryGetStringField(TEXT("function_name"), FunctionName);
 
     // Charger Blueprint - handle both full paths and simple names
-    UBlueprint* Blueprint = nullptr;
-    FString BlueprintPath = BlueprintName;
-
-    // If no path prefix, assume /Game/Blueprints/
-    if (!BlueprintPath.StartsWith(TEXT("/")))
-    {
-        BlueprintPath = TEXT("/Game/Blueprints/") + BlueprintPath;
-    }
-
-    // Add .Blueprint suffix if not present
-    if (!BlueprintPath.Contains(TEXT(".")))
-    {
-        BlueprintPath += TEXT(".") + FPaths::GetBaseFilename(BlueprintPath);
-    }
-
-    // Try to load the Blueprint
-    Blueprint = LoadObject<UBlueprint>(nullptr, *BlueprintPath);
-
-    // If not found, try with UEditorAssetLibrary
-    if (!Blueprint)
-    {
-        FString AssetPath = BlueprintPath;
-        if (UEditorAssetLibrary::DoesAssetExist(AssetPath))
-        {
-            UObject* Asset = UEditorAssetLibrary::LoadAsset(AssetPath);
-            Blueprint = Cast<UBlueprint>(Asset);
-        }
-    }
+    UBlueprint* Blueprint = LoadConnectorBlueprint(BlueprintName);
 
     if (!Blueprint)
     {
@@ -59,54 +93,7 @@ TSharedPtr<FJsonObject> FBPConnector::ConnectNodes(const TSharedPtr<FJsonObject>
         return Result;
     }
 
-    // Get graph
-    UEdGraph* Graph = nullptr;
-
-    if (!FunctionName.IsEmpty())
-    {
-        // Strategy 1: Try exact name match with GetFName()
-        for (UEdGraph* FuncGraph : Blueprint->FunctionGraphs)
-        {
-            if (FuncGraph && (FuncGraph->GetFName().ToString() == FunctionName ||
-                              (FuncGraph->GetOuter() && FuncGraph->GetOuter()->GetFName().ToString() == FunctionName)))
-            {
-                Graph = FuncGraph;
-                break;
-            }
-        }
-
-        // Strategy 2: Fallback - partial match for auto-generated names
-        if (!Graph)
-        {
-            for (UEdGraph* FuncGraph : Blueprint->FunctionGraphs)
-            {
-                if (FuncGraph && FuncGraph->GetFName().ToString().Contains(FunctionName))
-                {
-                    Graph = FuncGraph;
-                    break;
-                }
-            }
-        }
-
-        if (!Graph)
-        {
-            Result->SetBoolField("success", false);
-            Result->SetStringField("error", FString::Printf(TEXT("Function graph not found: %s"), *FunctionName));
-            return Result;
-        }
-    }
-    else
-    {
-        // Use event graph if no function specified
-        if (Blueprint->UbergraphPages.Num() == 0)
-        {
-            Result->SetBoolField("success", false);
-            Result->SetStringField("error", "Blueprint has no event graph");
-            return Result;
-        }
-
-        Graph = Blueprint->UbergraphPages[0];
-    }
+    UEdGraph* Graph = FindConnectorGraph(Blueprint, FunctionName);
 
     if (!Graph)
     {
@@ -137,23 +124,27 @@ TSharedPtr<FJsonObject> FBPConnector::ConnectNodes(const TSharedPtr<FJsonObject>
         return Result;
     }
 
-    // Validate compatibility
-    if (!ArePinsCompatible(SourcePin, TargetPin))
+    const UEdGraphSchema_K2* Schema = GetDefault<UEdGraphSchema_K2>();
+    if (!Schema || !Schema->TryCreateConnection(SourcePin, TargetPin))
     {
         Result->SetBoolField("success", false);
         Result->SetStringField("error", "Pins not compatible");
         return Result;
     }
 
-    // Create connection
-    SourcePin->MakeLinkTo(TargetPin);
+    bool bSkipCompile = false;
+    Params->TryGetBoolField(TEXT("skip_compile"), bSkipCompile);
 
-    // Recompile
     Blueprint->MarkPackageDirty();
-    FKismetEditorUtilities::CompileBlueprint(Blueprint);
+    Graph->NotifyGraphChanged();
+    if (!bSkipCompile)
+    {
+        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+    }
 
     // Return
     Result->SetBoolField("success", true);
+    Result->SetBoolField("compiled", !bSkipCompile);
 
     TSharedPtr<FJsonObject> ConnectionInfo = MakeShared<FJsonObject>();
     ConnectionInfo->SetStringField("source_node", SourceNodeId);
@@ -164,6 +155,73 @@ TSharedPtr<FJsonObject> FBPConnector::ConnectNodes(const TSharedPtr<FJsonObject>
 
     Result->SetObjectField("connection", ConnectionInfo);
 
+    return Result;
+}
+
+TSharedPtr<FJsonObject> FBPConnector::BreakPinLinks(const TSharedPtr<FJsonObject>& Params)
+{
+    TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+
+    FString BlueprintName = Params->GetStringField(TEXT("blueprint_name"));
+    FString NodeId = Params->GetStringField(TEXT("node_id"));
+    FString PinName = Params->GetStringField(TEXT("pin_name"));
+
+    FString FunctionName;
+    Params->TryGetStringField(TEXT("function_name"), FunctionName);
+
+    FString PinDirectionString;
+    Params->TryGetStringField(TEXT("pin_direction"), PinDirectionString);
+    EEdGraphPinDirection Direction = PinDirectionString.Equals(TEXT("input"), ESearchCase::IgnoreCase) ? EGPD_Input : EGPD_Output;
+
+    UBlueprint* Blueprint = LoadConnectorBlueprint(BlueprintName);
+    if (!Blueprint)
+    {
+        Result->SetBoolField("success", false);
+        Result->SetStringField("error", "Blueprint not found");
+        return Result;
+    }
+
+    UEdGraph* Graph = FindConnectorGraph(Blueprint, FunctionName);
+    if (!Graph)
+    {
+        Result->SetBoolField("success", false);
+        Result->SetStringField("error", "Graph not found");
+        return Result;
+    }
+
+    UK2Node* Node = FindNodeById(Graph, NodeId);
+    if (!Node)
+    {
+        Result->SetBoolField("success", false);
+        Result->SetStringField("error", "Node not found");
+        return Result;
+    }
+
+    UEdGraphPin* Pin = FindPinByName(Node, PinName, Direction);
+    if (!Pin)
+    {
+        Result->SetBoolField("success", false);
+        Result->SetStringField("error", "Pin not found");
+        return Result;
+    }
+
+    const int32 RemovedLinks = Pin->LinkedTo.Num();
+    if (const UEdGraphSchema_K2* Schema = GetDefault<UEdGraphSchema_K2>())
+    {
+        Schema->BreakPinLinks(*Pin, true);
+    }
+    else
+    {
+        Pin->BreakAllPinLinks(true);
+    }
+
+    Blueprint->MarkPackageDirty();
+    FKismetEditorUtilities::CompileBlueprint(Blueprint);
+
+    Result->SetBoolField("success", true);
+    Result->SetStringField("node", NodeId);
+    Result->SetStringField("pin", PinName);
+    Result->SetNumberField("removed_links", RemovedLinks);
     return Result;
 }
 
@@ -218,5 +276,6 @@ bool FBPConnector::ArePinsCompatible(UEdGraphPin* SourcePin, UEdGraphPin* Target
         return false;
     }
 
-    return SourcePin->PinType.PinCategory == TargetPin->PinType.PinCategory;
+    const UEdGraphSchema_K2* Schema = GetDefault<UEdGraphSchema_K2>();
+    return Schema && Schema->CanCreateConnection(SourcePin, TargetPin).Response != CONNECT_RESPONSE_DISALLOW;
 }

--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/BPVariables.cpp
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/BPVariables.cpp
@@ -9,6 +9,50 @@
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "PropertyEditorModule.h"
 #include "Modules/ModuleManager.h"
+#include "UObject/UnrealType.h"
+
+namespace
+{
+UClass* ResolveBlueprintGeneratedClass(const FString& ObjectPath)
+{
+    if (ObjectPath.IsEmpty())
+    {
+        return nullptr;
+    }
+
+    if (UClass* Class = LoadClass<UObject>(nullptr, *ObjectPath))
+    {
+        return Class;
+    }
+
+    if (UClass* Class = FindObject<UClass>(nullptr, *ObjectPath))
+    {
+        return Class;
+    }
+
+    if (UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *ObjectPath))
+    {
+        return Blueprint->GeneratedClass;
+    }
+
+    return nullptr;
+}
+
+UObject* ResolveTypeObject(const FString& ObjectPath)
+{
+    if (ObjectPath.IsEmpty())
+    {
+        return nullptr;
+    }
+
+    if (UObject* Object = StaticLoadObject(UObject::StaticClass(), nullptr, *ObjectPath))
+    {
+        return Object;
+    }
+
+    return FindObject<UObject>(nullptr, *ObjectPath);
+}
+}
 
 TSharedPtr<FJsonObject> FBPVariables::CreateVariable(const TSharedPtr<FJsonObject>& Params)
 {
@@ -396,33 +440,81 @@ TSharedPtr<FJsonObject> FBPVariables::SetVariableProperties(const TSharedPtr<FJs
 FEdGraphPinType FBPVariables::GetPinTypeFromString(const FString& TypeString)
 {
     FEdGraphPinType PinType;
+    FString WorkingType = TypeString;
+    if (WorkingType.StartsWith(TEXT("array:")))
+    {
+        WorkingType.RightChopInline(6);
+        PinType.ContainerType = EPinContainerType::Array;
+    }
 
-    if (TypeString == "bool")
+    if (WorkingType == "bool")
     {
         PinType.PinCategory = UEdGraphSchema_K2::PC_Boolean;
     }
-    else if (TypeString == "int")
+    else if (WorkingType == "int")
     {
         PinType.PinCategory = UEdGraphSchema_K2::PC_Int;
     }
-    else if (TypeString == "float")
+    else if (WorkingType == "float")
     {
         PinType.PinCategory = UEdGraphSchema_K2::PC_Real;
         PinType.PinSubCategory = UEdGraphSchema_K2::PC_Float;
     }
-    else if (TypeString == "string")
+    else if (WorkingType == "string")
     {
         PinType.PinCategory = UEdGraphSchema_K2::PC_String;
     }
-    else if (TypeString == "vector")
+    else if (WorkingType == "text")
+    {
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Text;
+    }
+    else if (WorkingType == "name")
+    {
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Name;
+    }
+    else if (WorkingType == "byte")
+    {
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Byte;
+    }
+    else if (WorkingType == "vector")
     {
         PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
         PinType.PinSubCategoryObject = TBaseStructure<FVector>::Get();
     }
-    else if (TypeString == "rotator")
+    else if (WorkingType == "vector2d")
+    {
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
+        PinType.PinSubCategoryObject = TBaseStructure<FVector2D>::Get();
+    }
+    else if (WorkingType == "rotator")
     {
         PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
         PinType.PinSubCategoryObject = TBaseStructure<FRotator>::Get();
+    }
+    else if (WorkingType == "intpoint")
+    {
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
+        PinType.PinSubCategoryObject = TBaseStructure<FIntPoint>::Get();
+    }
+    else if (WorkingType.StartsWith(TEXT("enum:")))
+    {
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Byte;
+        PinType.PinSubCategoryObject = Cast<UEnum>(ResolveTypeObject(WorkingType.RightChop(5)));
+    }
+    else if (WorkingType.StartsWith(TEXT("struct:")))
+    {
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
+        PinType.PinSubCategoryObject = Cast<UScriptStruct>(ResolveTypeObject(WorkingType.RightChop(7)));
+    }
+    else if (WorkingType.StartsWith(TEXT("object:")))
+    {
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Object;
+        PinType.PinSubCategoryObject = ResolveBlueprintGeneratedClass(WorkingType.RightChop(7));
+    }
+    else if (WorkingType.StartsWith(TEXT("class:")))
+    {
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Class;
+        PinType.PinSubCategoryObject = ResolveBlueprintGeneratedClass(WorkingType.RightChop(6));
     }
     else
     {

--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/Function/FunctionIO.cpp
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/Function/FunctionIO.cpp
@@ -9,6 +9,8 @@
 #include "K2Node_CallFunction.h"
 #include "EditorAssetLibrary.h"
 #include "EdGraph/EdGraphNode.h"
+#include "UObject/Class.h"
+#include "UObject/UnrealType.h"
 
 TSharedPtr<FJsonObject> FFunctionIO::AddFunctionIO(const TSharedPtr<FJsonObject>& Params)
 {
@@ -158,6 +160,10 @@ bool FFunctionIO::AddFunctionParameter(
 
 	// Create the property type
 	FEdGraphPinType PropertyType = GetPropertyTypeFromString(ParamType);
+	if (bIsArray)
+	{
+		PropertyType.ContainerType = EPinContainerType::Array;
+	}
 
 	UEdGraphPin* NewPin = nullptr;
 
@@ -328,14 +334,60 @@ FEdGraphPinType FFunctionIO::GetPropertyTypeFromString(const FString& TypeName)
 		PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
 		PinType.PinSubCategoryObject = TBaseStructure<FVector>::Get();
 	}
+	else if (TypeName == TEXT("vector2d") || TypeName == TEXT("FVector2D"))
+	{
+		PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
+		PinType.PinSubCategoryObject = TBaseStructure<FVector2D>::Get();
+	}
 	else if (TypeName == TEXT("rotator") || TypeName == TEXT("FRotator"))
 	{
 		PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
 		PinType.PinSubCategoryObject = TBaseStructure<FRotator>::Get();
 	}
+	else if (TypeName == TEXT("intpoint") || TypeName == TEXT("FIntPoint"))
+	{
+		PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
+		PinType.PinSubCategoryObject = TBaseStructure<FIntPoint>::Get();
+	}
+	else if (TypeName == TEXT("name") || TypeName == TEXT("FName"))
+	{
+		PinType.PinCategory = UEdGraphSchema_K2::PC_Name;
+	}
 	else if (TypeName == TEXT("object"))
 	{
 		PinType.PinCategory = UEdGraphSchema_K2::PC_Object;
+	}
+	else if (TypeName.StartsWith(TEXT("enum:"), ESearchCase::IgnoreCase))
+	{
+		const FString EnumPath = TypeName.RightChop(5);
+		if (UEnum* EnumType = LoadObject<UEnum>(nullptr, *EnumPath))
+		{
+			PinType.PinCategory = UEdGraphSchema_K2::PC_Byte;
+			PinType.PinSubCategoryObject = EnumType;
+		}
+		else
+		{
+			PinType.PinCategory = UEdGraphSchema_K2::PC_Byte;
+		}
+	}
+	else if (TypeName.StartsWith(TEXT("struct:"), ESearchCase::IgnoreCase))
+	{
+		const FString StructPath = TypeName.RightChop(7);
+		if (UScriptStruct* StructType = LoadObject<UScriptStruct>(nullptr, *StructPath))
+		{
+			PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
+			PinType.PinSubCategoryObject = StructType;
+		}
+		else
+		{
+			PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
+		}
+	}
+	else if (TypeName.StartsWith(TEXT("object:"), ESearchCase::IgnoreCase))
+	{
+		const FString ClassPath = TypeName.RightChop(7);
+		PinType.PinCategory = UEdGraphSchema_K2::PC_Object;
+		PinType.PinSubCategoryObject = LoadObject<UClass>(nullptr, *ClassPath);
 	}
 	else
 	{

--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/NodeManager.cpp
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/NodeManager.cpp
@@ -10,6 +10,7 @@
 #include "EdGraphSchema_K2.h"
 #include "K2Node_CallFunction.h"
 #include "K2Node_Event.h"
+#include "K2Node_EnhancedInputAction.h"
 #include "K2Node_VariableGet.h"
 #include "K2Node_VariableSet.h"
 #include "K2Node_PromotableOperator.h"
@@ -20,6 +21,56 @@
 #include "EditorAssetLibrary.h"
 #include "Kismet/KismetSystemLibrary.h"
 #include "Kismet/KismetMathLibrary.h"
+#include "InputAction.h"
+
+namespace
+{
+	FString ResolveStandardMacroAlias(const FString& NodeType)
+	{
+		FString CompactNodeType = NodeType;
+		CompactNodeType.ReplaceInline(TEXT("_"), TEXT(""));
+		CompactNodeType.ReplaceInline(TEXT("-"), TEXT(""));
+		CompactNodeType.ReplaceInline(TEXT(" "), TEXT(""));
+
+		if (CompactNodeType.Equals(TEXT("ForEach"), ESearchCase::IgnoreCase) ||
+			CompactNodeType.Equals(TEXT("ForEachLoop"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("ForEachLoop");
+		}
+
+		if (CompactNodeType.Equals(TEXT("ForEachWithBreak"), ESearchCase::IgnoreCase) ||
+			CompactNodeType.Equals(TEXT("ForEachLoopWithBreak"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("ForEachLoopWithBreak");
+		}
+
+		if (CompactNodeType.Equals(TEXT("ReverseForEach"), ESearchCase::IgnoreCase) ||
+			CompactNodeType.Equals(TEXT("ReverseForEachLoop"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("ReverseForEachLoop");
+		}
+
+		if (CompactNodeType.Equals(TEXT("For"), ESearchCase::IgnoreCase) ||
+			CompactNodeType.Equals(TEXT("ForLoop"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("ForLoop");
+		}
+
+		if (CompactNodeType.Equals(TEXT("ForWithBreak"), ESearchCase::IgnoreCase) ||
+			CompactNodeType.Equals(TEXT("ForLoopWithBreak"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("ForLoopWithBreak");
+		}
+
+		if (CompactNodeType.Equals(TEXT("While"), ESearchCase::IgnoreCase) ||
+			CompactNodeType.Equals(TEXT("WhileLoop"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("WhileLoop");
+		}
+
+		return FString();
+	}
+}
 
 TSharedPtr<FJsonObject> FBlueprintNodeManager::AddNode(const TSharedPtr<FJsonObject>& Params)
 {
@@ -152,6 +203,28 @@ TSharedPtr<FJsonObject> FBlueprintNodeManager::AddNode(const TSharedPtr<FJsonObj
 	{
 		NewNode = FDataNodeCreator::CreateMakeArrayNode(Graph, NodeParams);
 	}
+	else if (NodeType.Equals(TEXT("MakeStruct"), ESearchCase::IgnoreCase))
+	{
+		NewNode = FDataNodeCreator::CreateMakeStructNode(Graph, NodeParams);
+	}
+	else if (NodeType.Equals(TEXT("BreakStruct"), ESearchCase::IgnoreCase))
+	{
+		NewNode = FDataNodeCreator::CreateBreakStructNode(Graph, NodeParams);
+	}
+	else if (NodeType.Equals(TEXT("SetFieldsInStruct"), ESearchCase::IgnoreCase) ||
+			 NodeType.Equals(TEXT("SetMembersInStruct"), ESearchCase::IgnoreCase) ||
+			 NodeType.Equals(TEXT("SetStructFields"), ESearchCase::IgnoreCase))
+	{
+		NewNode = FDataNodeCreator::CreateSetFieldsInStructNode(Graph, NodeParams);
+	}
+	else if (NodeType.Equals(TEXT("ArrayGet"), ESearchCase::IgnoreCase))
+	{
+		NewNode = FDataNodeCreator::CreateArrayGetNode(Graph, NodeParams);
+	}
+	else if (NodeType.Equals(TEXT("CallArrayFunction"), ESearchCase::IgnoreCase))
+	{
+		NewNode = FDataNodeCreator::CreateCallArrayFunctionNode(Graph, NodeParams);
+	}
 	// Utility Nodes
 	else if (NodeType.Equals(TEXT("Print"), ESearchCase::IgnoreCase))
 	{
@@ -160,6 +233,10 @@ TSharedPtr<FJsonObject> FBlueprintNodeManager::AddNode(const TSharedPtr<FJsonObj
 	else if (NodeType.Equals(TEXT("CallFunction"), ESearchCase::IgnoreCase))
 	{
 		NewNode = FUtilityNodeCreator::CreateCallFunctionNode(Graph, NodeParams);
+	}
+	else if (NodeType.Equals(TEXT("EnhancedInputAction"), ESearchCase::IgnoreCase))
+	{
+		NewNode = CreateEnhancedInputActionNode(Graph, NodeParams);
 	}
 	else if (NodeType.Equals(TEXT("Select"), ESearchCase::IgnoreCase))
 	{
@@ -208,14 +285,31 @@ TSharedPtr<FJsonObject> FBlueprintNodeManager::AddNode(const TSharedPtr<FJsonObj
 	{
 		NewNode = FSpecializedNodeCreator::CreateKnotNode(Graph, NodeParams);
 	}
-	// Event nodes (kept for backward compatibility - should use add_event_node)
-	else if (NodeType.Equals(TEXT("Event"), ESearchCase::IgnoreCase))
-	{
-		NewNode = CreateEventNode(Graph, NodeParams);
-	}
 	else
 	{
-		return CreateErrorResponse(FString::Printf(TEXT("Unknown node type: %s"), *NodeType));
+		const FString StandardMacroName = ResolveStandardMacroAlias(NodeType);
+		if (!StandardMacroName.IsEmpty())
+		{
+			NodeParams->SetStringField(TEXT("macro_name"), StandardMacroName);
+			NewNode = FSpecializedNodeCreator::CreateMacroInstanceNode(Graph, NodeParams);
+		}
+		else if (NodeType.Equals(TEXT("MacroInstance"), ESearchCase::IgnoreCase))
+		{
+			NewNode = FSpecializedNodeCreator::CreateMacroInstanceNode(Graph, NodeParams);
+		}
+		else if (NodeType.Equals(TEXT("FunctionResult"), ESearchCase::IgnoreCase))
+		{
+			NewNode = FSpecializedNodeCreator::CreateFunctionResultNode(Graph, NodeParams);
+		}
+		// Event nodes (kept for backward compatibility - should use add_event_node)
+		else if (NodeType.Equals(TEXT("Event"), ESearchCase::IgnoreCase))
+		{
+			NewNode = CreateEventNode(Graph, NodeParams);
+		}
+		else
+		{
+			return CreateErrorResponse(FString::Printf(TEXT("Unknown node type: %s"), *NodeType));
+		}
 	}
 
 	if (!NewNode)
@@ -485,6 +579,54 @@ UK2Node* FBlueprintNodeManager::CreateCallFunctionNode(UEdGraph* Graph, const TS
 	CallNode->AllocateDefaultPins();
 
 	return CallNode;
+}
+
+UK2Node* FBlueprintNodeManager::CreateEnhancedInputActionNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
+{
+	if (!Graph || !Params.IsValid())
+	{
+		return nullptr;
+	}
+
+	FString InputActionPath;
+	if (!Params->TryGetStringField(TEXT("input_action"), InputActionPath) || InputActionPath.IsEmpty())
+	{
+		return nullptr;
+	}
+
+	UInputAction* InputAction = LoadObject<UInputAction>(nullptr, *InputActionPath);
+	if (!InputAction && !InputActionPath.Contains(TEXT(".")))
+	{
+		const FString ObjectPath = InputActionPath + TEXT(".") + FPaths::GetBaseFilename(InputActionPath);
+		InputAction = LoadObject<UInputAction>(nullptr, *ObjectPath);
+	}
+
+	if (!InputAction)
+	{
+		return nullptr;
+	}
+
+	UK2Node_EnhancedInputAction* InputActionNode = NewObject<UK2Node_EnhancedInputAction>(Graph);
+	if (!InputActionNode)
+	{
+		return nullptr;
+	}
+
+	double PosX = 0.0;
+	double PosY = 0.0;
+	Params->TryGetNumberField(TEXT("pos_x"), PosX);
+	Params->TryGetNumberField(TEXT("pos_y"), PosY);
+
+	InputActionNode->InputAction = InputAction;
+	InputActionNode->NodePosX = static_cast<int32>(PosX);
+	InputActionNode->NodePosY = static_cast<int32>(PosY);
+
+	Graph->AddNode(InputActionNode, true, false);
+	InputActionNode->CreateNewGuid();
+	InputActionNode->PostPlacedNewNode();
+	InputActionNode->AllocateDefaultPins();
+
+	return InputActionNode;
 }
 
 UK2Node* FBlueprintNodeManager::CreateComparisonNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)

--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/NodePropertyManager.cpp
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/NodePropertyManager.cpp
@@ -26,6 +26,24 @@
 #include "EditorAssetLibrary.h"
 #include "Json.h"
 
+namespace
+{
+UClass* ResolveBlueprintCallableClass(const FString& ClassPath)
+{
+	if (ClassPath.IsEmpty())
+	{
+		return UKismetSystemLibrary::StaticClass();
+	}
+
+	if (UClass* FoundClass = FindObject<UClass>(nullptr, *ClassPath))
+	{
+		return FoundClass;
+	}
+
+	return LoadObject<UClass>(nullptr, *ClassPath);
+}
+}
+
 TSharedPtr<FJsonObject> FNodePropertyManager::SetNodeProperty(const TSharedPtr<FJsonObject>& Params)
 {
 	// Validate parameters
@@ -345,6 +363,57 @@ TSharedPtr<FJsonObject> FNodePropertyManager::DispatchEditAction(
 		}
 	}
 
+	// === CALLFUNCTION: Change the referenced UFunction ===
+	if (Action.Equals(TEXT("set_function_call"), ESearchCase::IgnoreCase))
+	{
+		UK2Node_CallFunction* CallFunctionNode = Cast<UK2Node_CallFunction>(Node);
+		if (!CallFunctionNode)
+		{
+			return CreateErrorResponse(TEXT("Node is not a CallFunction node"));
+		}
+
+		FString TargetFunction;
+		if (!Params->TryGetStringField(TEXT("target_function"), TargetFunction) || TargetFunction.IsEmpty())
+		{
+			return CreateErrorResponse(TEXT("Missing 'target_function' parameter"));
+		}
+
+		FString TargetClassPath;
+		Params->TryGetStringField(TEXT("target_class"), TargetClassPath);
+
+		UClass* TargetClass = ResolveBlueprintCallableClass(TargetClassPath);
+		if (!TargetClass)
+		{
+			return CreateErrorResponse(FString::Printf(TEXT("Target class not found: %s"), *TargetClassPath));
+		}
+
+		UFunction* TargetFunc = TargetClass->FindFunctionByName(FName(*TargetFunction));
+		if (!TargetFunc)
+		{
+			return CreateErrorResponse(FString::Printf(
+				TEXT("Function '%s' not found on class '%s'"),
+				*TargetFunction,
+				*TargetClass->GetName()));
+		}
+
+		CallFunctionNode->Modify();
+		CallFunctionNode->SetFromFunction(TargetFunc);
+		CallFunctionNode->ReconstructNode();
+
+		Graph->NotifyGraphChanged();
+		if (UBlueprint* Blueprint = FBlueprintEditorUtils::FindBlueprintForGraph(Graph))
+		{
+			FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
+		}
+
+		TSharedPtr<FJsonObject> Response = MakeShareable(new FJsonObject);
+		Response->SetBoolField(TEXT("success"), true);
+		Response->SetStringField(TEXT("action"), TEXT("set_function_call"));
+		Response->SetStringField(TEXT("target_function"), TargetFunction);
+		Response->SetStringField(TEXT("target_class"), TargetClass->GetPathName());
+		return Response;
+	}
+
 	// Unknown action
 	return CreateErrorResponse(FString::Printf(TEXT("Unknown action: %s"), *Action));
 }
@@ -469,6 +538,45 @@ bool FNodePropertyManager::SetGenericNodeProperty(
 		{
 			Node->NodeComment = Comment;
 			return true;
+		}
+	}
+
+	// Handle "pin_default:<PinName>" for generic pin default authoring.
+	if (PropertyName.StartsWith(TEXT("pin_default:"), ESearchCase::IgnoreCase))
+	{
+		const FString PinName = PropertyName.RightChop(12);
+		FString DefaultValue;
+		if (!PinName.IsEmpty() && Value->TryGetString(DefaultValue))
+		{
+			if (UEdGraphPin* Pin = Node->FindPin(FName(*PinName)))
+			{
+				Pin->DefaultValue = DefaultValue;
+				return true;
+			}
+		}
+	}
+
+	if (PropertyName.StartsWith(TEXT("pin_default_object:"), ESearchCase::IgnoreCase))
+	{
+		const FString PinName = PropertyName.RightChop(19);
+		FString ObjectPath;
+		if (!PinName.IsEmpty() && Value->TryGetString(ObjectPath))
+		{
+			if (UEdGraphPin* Pin = Node->FindPin(FName(*PinName)))
+			{
+				UObject* LoadedObject = LoadObject<UObject>(nullptr, *ObjectPath);
+				if (!LoadedObject)
+				{
+					LoadedObject = StaticLoadObject(UObject::StaticClass(), nullptr, *ObjectPath);
+				}
+				if (LoadedObject)
+				{
+					Pin->DefaultObject = LoadedObject;
+					Pin->DefaultValue.Reset();
+					Pin->DefaultTextValue = FText::GetEmpty();
+					return true;
+				}
+			}
 		}
 	}
 

--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/Nodes/CastingNodes.cpp
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/Nodes/CastingNodes.cpp
@@ -4,7 +4,35 @@
 #include "K2Node_CastByteToEnum.h"
 #include "K2Node_ClassDynamicCast.h"
 #include "K2Node_DynamicCast.h"
+#include "Engine/Blueprint.h"
 
+namespace
+{
+UClass* ResolveClassForCastNode(const FString& ClassPath)
+{
+  if (ClassPath.IsEmpty())
+  {
+    return nullptr;
+  }
+
+  if (UClass* Class = Cast<UClass>(StaticFindObject(UClass::StaticClass(), nullptr, *ClassPath)))
+  {
+    return Class;
+  }
+
+  if (UClass* Class = LoadObject<UClass>(nullptr, *ClassPath))
+  {
+    return Class;
+  }
+
+  if (UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *ClassPath))
+  {
+    return Blueprint->GeneratedClass;
+  }
+
+  return nullptr;
+}
+}
 
 UK2Node *FCastingNodeCreator::CreateDynamicCastNode(
     UEdGraph *Graph, const TSharedPtr<FJsonObject> &Params) {
@@ -20,8 +48,7 @@ UK2Node *FCastingNodeCreator::CreateDynamicCastNode(
   // Set target class BEFORE initialization
   FString TargetClass;
   if (Params->TryGetStringField(TEXT("target_class"), TargetClass)) {
-    UClass *CastClass = Cast<UClass>(
-        StaticFindObject(UClass::StaticClass(), nullptr, *TargetClass));
+    UClass *CastClass = ResolveClassForCastNode(TargetClass);
     if (CastClass) {
       DynamicCastNode->TargetType = CastClass;
     }
@@ -53,8 +80,7 @@ UK2Node *FCastingNodeCreator::CreateClassDynamicCastNode(
   // Set target class BEFORE initialization
   FString TargetClass;
   if (Params->TryGetStringField(TEXT("target_class"), TargetClass)) {
-    UClass *CastClass = Cast<UClass>(
-        StaticFindObject(UClass::StaticClass(), nullptr, *TargetClass));
+    UClass *CastClass = ResolveClassForCastNode(TargetClass);
     if (CastClass) {
       ClassDynamicCastNode->TargetType = CastClass;
     }

--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/Nodes/DataNodes.cpp
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/Nodes/DataNodes.cpp
@@ -3,7 +3,130 @@
 #include "K2Node_VariableGet.h"
 #include "K2Node_VariableSet.h"
 #include "K2Node_MakeArray.h"
+#include "K2Node_MakeStruct.h"
+#include "K2Node_BreakStruct.h"
+#include "K2Node_SetFieldsInStruct.h"
+#include "K2Node_GetArrayItem.h"
+#include "K2Node_CallArrayFunction.h"
+#include "Engine/Blueprint.h"
+#include "Kismet/KismetArrayLibrary.h"
+#include "UObject/UnrealType.h"
 #include "Json.h"
+
+namespace
+{
+	UScriptStruct* ResolveScriptStruct(const FString& StructPath)
+	{
+		if (StructPath.IsEmpty())
+		{
+			return nullptr;
+		}
+
+		if (UScriptStruct* FoundStruct = FindObject<UScriptStruct>(nullptr, *StructPath))
+		{
+			return FoundStruct;
+		}
+
+		return LoadObject<UScriptStruct>(nullptr, *StructPath);
+	}
+
+	void AddRequestedFieldName(const UScriptStruct* StructType, const FString& RequestedName, TSet<FName>& FieldNames)
+	{
+		if (RequestedName.IsEmpty())
+		{
+			return;
+		}
+
+		if (StructType)
+		{
+			for (TFieldIterator<FProperty> PropIt(StructType, EFieldIteratorFlags::IncludeSuper); PropIt; ++PropIt)
+			{
+				FProperty* Property = *PropIt;
+				if (Property && Property->GetName().Equals(RequestedName, ESearchCase::IgnoreCase))
+				{
+					FieldNames.Add(Property->GetFName());
+					return;
+				}
+			}
+		}
+
+		FieldNames.Add(FName(*RequestedName));
+	}
+
+	void AddRequestedFieldArray(const TSharedPtr<FJsonObject>& Params, const TCHAR* FieldName, const UScriptStruct* StructType, TSet<FName>& FieldNames)
+	{
+		const TArray<TSharedPtr<FJsonValue>>* RequestedFields = nullptr;
+		if (!Params->TryGetArrayField(FieldName, RequestedFields))
+		{
+			return;
+		}
+
+		for (const TSharedPtr<FJsonValue>& FieldValue : *RequestedFields)
+		{
+			FString RequestedName;
+			if (FieldValue.IsValid() && FieldValue->TryGetString(RequestedName))
+			{
+				AddRequestedFieldName(StructType, RequestedName, FieldNames);
+			}
+		}
+	}
+
+	TSet<FName> GetRequestedStructFields(const TSharedPtr<FJsonObject>& Params, const UScriptStruct* StructType)
+	{
+		TSet<FName> FieldNames;
+
+		bool bShowAllFields = false;
+		bool bBoolValue = false;
+		if (Params->TryGetBoolField(TEXT("show_all_pins"), bBoolValue))
+		{
+			bShowAllFields |= bBoolValue;
+		}
+		if (Params->TryGetBoolField(TEXT("show_all_fields"), bBoolValue))
+		{
+			bShowAllFields |= bBoolValue;
+		}
+
+		if (bShowAllFields && StructType)
+		{
+			for (TFieldIterator<FProperty> PropIt(StructType, EFieldIteratorFlags::IncludeSuper); PropIt; ++PropIt)
+			{
+				if (FProperty* Property = *PropIt)
+				{
+					FieldNames.Add(Property->GetFName());
+				}
+			}
+		}
+
+		FString SingleFieldName;
+		if (Params->TryGetStringField(TEXT("field_name"), SingleFieldName))
+		{
+			AddRequestedFieldName(StructType, SingleFieldName, FieldNames);
+		}
+
+		AddRequestedFieldArray(Params, TEXT("field_names"), StructType, FieldNames);
+		AddRequestedFieldArray(Params, TEXT("fields"), StructType, FieldNames);
+		AddRequestedFieldArray(Params, TEXT("member_names"), StructType, FieldNames);
+
+		return FieldNames;
+	}
+
+	void PrimeVisibleStructFields(UK2Node_SetFieldsInStruct* SetFieldsNode, const TSet<FName>& FieldNames)
+	{
+		if (!SetFieldsNode || FieldNames.IsEmpty())
+		{
+			return;
+		}
+
+		SetFieldsNode->ShowPinForProperties.Reset();
+		for (const FName& FieldName : FieldNames)
+		{
+			FOptionalPinFromProperty& PinRecord = SetFieldsNode->ShowPinForProperties.AddDefaulted_GetRef();
+			PinRecord.PropertyName = FieldName;
+			PinRecord.bShowPin = true;
+			PinRecord.bCanToggleVisibility = true;
+		}
+	}
+}
 
 UK2Node* FDataNodeCreator::CreateVariableGetNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
 {
@@ -24,7 +147,22 @@ UK2Node* FDataNodeCreator::CreateVariableGetNode(UEdGraph* Graph, const TSharedP
 		return nullptr;
 	}
 
-	VarGetNode->VariableReference.SetSelfMember(FName(*VariableName));
+	FString TargetBlueprintPath;
+	if (Params->TryGetStringField(TEXT("target_blueprint"), TargetBlueprintPath))
+	{
+		if (UBlueprint* TargetBlueprint = LoadObject<UBlueprint>(nullptr, *TargetBlueprintPath))
+		{
+			VarGetNode->VariableReference.SetExternalMember(FName(*VariableName), TargetBlueprint->GeneratedClass);
+		}
+		else
+		{
+			VarGetNode->VariableReference.SetSelfMember(FName(*VariableName));
+		}
+	}
+	else
+	{
+		VarGetNode->VariableReference.SetSelfMember(FName(*VariableName));
+	}
 
 	double PosX, PosY;
 	FNodeCreatorUtils::ExtractNodePosition(Params, PosX, PosY);
@@ -92,5 +230,182 @@ UK2Node* FDataNodeCreator::CreateMakeArrayNode(UEdGraph* Graph, const TSharedPtr
 	FNodeCreatorUtils::InitializeK2Node(MakeArrayNode, Graph);
 
 	return MakeArrayNode;
+}
+
+UK2Node* FDataNodeCreator::CreateMakeStructNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
+{
+	if (!Graph || !Params.IsValid())
+	{
+		return nullptr;
+	}
+
+	FString StructPath;
+	if (!Params->TryGetStringField(TEXT("struct_path"), StructPath))
+	{
+		Params->TryGetStringField(TEXT("target_blueprint"), StructPath);
+	}
+
+	UScriptStruct* StructType = ResolveScriptStruct(StructPath);
+	if (!StructType)
+	{
+		return nullptr;
+	}
+
+	UK2Node_MakeStruct* MakeStructNode = NewObject<UK2Node_MakeStruct>(Graph);
+	if (!MakeStructNode)
+	{
+		return nullptr;
+	}
+
+	MakeStructNode->StructType = StructType;
+
+	double PosX, PosY;
+	FNodeCreatorUtils::ExtractNodePosition(Params, PosX, PosY);
+	MakeStructNode->NodePosX = static_cast<int32>(PosX);
+	MakeStructNode->NodePosY = static_cast<int32>(PosY);
+
+	Graph->AddNode(MakeStructNode, true, false);
+	FNodeCreatorUtils::InitializeK2Node(MakeStructNode, Graph);
+
+	return MakeStructNode;
+}
+
+UK2Node* FDataNodeCreator::CreateBreakStructNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
+{
+	if (!Graph || !Params.IsValid())
+	{
+		return nullptr;
+	}
+
+	FString StructPath;
+	if (!Params->TryGetStringField(TEXT("struct_path"), StructPath))
+	{
+		Params->TryGetStringField(TEXT("target_blueprint"), StructPath);
+	}
+
+	UScriptStruct* StructType = ResolveScriptStruct(StructPath);
+	if (!StructType)
+	{
+		return nullptr;
+	}
+
+	UK2Node_BreakStruct* BreakStructNode = NewObject<UK2Node_BreakStruct>(Graph);
+	if (!BreakStructNode)
+	{
+		return nullptr;
+	}
+
+	BreakStructNode->StructType = StructType;
+
+	double PosX, PosY;
+	FNodeCreatorUtils::ExtractNodePosition(Params, PosX, PosY);
+	BreakStructNode->NodePosX = static_cast<int32>(PosX);
+	BreakStructNode->NodePosY = static_cast<int32>(PosY);
+
+	Graph->AddNode(BreakStructNode, true, false);
+	FNodeCreatorUtils::InitializeK2Node(BreakStructNode, Graph);
+
+	return BreakStructNode;
+}
+
+UK2Node* FDataNodeCreator::CreateSetFieldsInStructNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
+{
+	if (!Graph || !Params.IsValid())
+	{
+		return nullptr;
+	}
+
+	FString StructPath;
+	if (!Params->TryGetStringField(TEXT("struct_path"), StructPath))
+	{
+		Params->TryGetStringField(TEXT("target_blueprint"), StructPath);
+	}
+
+	UScriptStruct* StructType = ResolveScriptStruct(StructPath);
+	if (!StructType)
+	{
+		return nullptr;
+	}
+
+	UK2Node_SetFieldsInStruct* SetFieldsNode = NewObject<UK2Node_SetFieldsInStruct>(Graph);
+	if (!SetFieldsNode)
+	{
+		return nullptr;
+	}
+
+	SetFieldsNode->StructType = StructType;
+	PrimeVisibleStructFields(SetFieldsNode, GetRequestedStructFields(Params, StructType));
+
+	double PosX, PosY;
+	FNodeCreatorUtils::ExtractNodePosition(Params, PosX, PosY);
+	SetFieldsNode->NodePosX = static_cast<int32>(PosX);
+	SetFieldsNode->NodePosY = static_cast<int32>(PosY);
+
+	Graph->AddNode(SetFieldsNode, true, false);
+	FNodeCreatorUtils::InitializeK2Node(SetFieldsNode, Graph);
+
+	return SetFieldsNode;
+}
+
+UK2Node* FDataNodeCreator::CreateArrayGetNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
+{
+	if (!Graph || !Params.IsValid())
+	{
+		return nullptr;
+	}
+
+	UK2Node_GetArrayItem* ArrayGetNode = NewObject<UK2Node_GetArrayItem>(Graph);
+	if (!ArrayGetNode)
+	{
+		return nullptr;
+	}
+
+	double PosX, PosY;
+	FNodeCreatorUtils::ExtractNodePosition(Params, PosX, PosY);
+	ArrayGetNode->NodePosX = static_cast<int32>(PosX);
+	ArrayGetNode->NodePosY = static_cast<int32>(PosY);
+
+	Graph->AddNode(ArrayGetNode, true, false);
+	FNodeCreatorUtils::InitializeK2Node(ArrayGetNode, Graph);
+
+	return ArrayGetNode;
+}
+
+UK2Node* FDataNodeCreator::CreateCallArrayFunctionNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
+{
+	if (!Graph || !Params.IsValid())
+	{
+		return nullptr;
+	}
+
+	FString TargetFunction;
+	if (!Params->TryGetStringField(TEXT("target_function"), TargetFunction))
+	{
+		return nullptr;
+	}
+
+	UFunction* TargetFunc = UKismetArrayLibrary::StaticClass()->FindFunctionByName(FName(*TargetFunction));
+	if (!TargetFunc)
+	{
+		return nullptr;
+	}
+
+	UK2Node_CallArrayFunction* CallArrayNode = NewObject<UK2Node_CallArrayFunction>(Graph);
+	if (!CallArrayNode)
+	{
+		return nullptr;
+	}
+
+	CallArrayNode->SetFromFunction(TargetFunc);
+
+	double PosX, PosY;
+	FNodeCreatorUtils::ExtractNodePosition(Params, PosX, PosY);
+	CallArrayNode->NodePosX = static_cast<int32>(PosX);
+	CallArrayNode->NodePosY = static_cast<int32>(PosY);
+
+	Graph->AddNode(CallArrayNode, true, false);
+	FNodeCreatorUtils::InitializeK2Node(CallArrayNode, Graph);
+
+	return CallArrayNode;
 }
 

--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/Nodes/SpecializedNodes.cpp
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/Nodes/SpecializedNodes.cpp
@@ -5,8 +5,84 @@
 #include "K2Node_Self.h"
 #include "K2Node_ConstructObjectFromClass.h"
 #include "K2Node_Knot.h"
+#include "K2Node_MacroInstance.h"
+#include "K2Node_FunctionResult.h"
 #include "EdGraphSchema_K2.h"
+#include "Engine/Blueprint.h"
 #include "Json.h"
+
+namespace
+{
+	UEdGraph* ResolveMacroGraph(const FString& MacroBlueprintPath, const FString& MacroName)
+	{
+		if (MacroName.IsEmpty())
+		{
+			return nullptr;
+		}
+
+		UBlueprint* MacroBlueprint = LoadObject<UBlueprint>(nullptr, *MacroBlueprintPath);
+		if (!MacroBlueprint)
+		{
+			return nullptr;
+		}
+
+		for (UEdGraph* MacroGraph : MacroBlueprint->MacroGraphs)
+		{
+			if (MacroGraph && MacroGraph->GetName().Equals(MacroName, ESearchCase::IgnoreCase))
+			{
+				return MacroGraph;
+			}
+		}
+
+		return nullptr;
+	}
+
+	FString NormalizeStandardMacroName(const FString& MacroName)
+	{
+		FString CompactMacroName = MacroName;
+		CompactMacroName.ReplaceInline(TEXT("_"), TEXT(""));
+		CompactMacroName.ReplaceInline(TEXT("-"), TEXT(""));
+		CompactMacroName.ReplaceInline(TEXT(" "), TEXT(""));
+
+		if (CompactMacroName.Equals(TEXT("ForEach"), ESearchCase::IgnoreCase) ||
+			CompactMacroName.Equals(TEXT("ForEachLoop"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("ForEachLoop");
+		}
+
+		if (CompactMacroName.Equals(TEXT("ForEachWithBreak"), ESearchCase::IgnoreCase) ||
+			CompactMacroName.Equals(TEXT("ForEachLoopWithBreak"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("ForEachLoopWithBreak");
+		}
+
+		if (CompactMacroName.Equals(TEXT("ReverseForEach"), ESearchCase::IgnoreCase) ||
+			CompactMacroName.Equals(TEXT("ReverseForEachLoop"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("ReverseForEachLoop");
+		}
+
+		if (CompactMacroName.Equals(TEXT("For"), ESearchCase::IgnoreCase) ||
+			CompactMacroName.Equals(TEXT("ForLoop"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("ForLoop");
+		}
+
+		if (CompactMacroName.Equals(TEXT("ForWithBreak"), ESearchCase::IgnoreCase) ||
+			CompactMacroName.Equals(TEXT("ForLoopWithBreak"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("ForLoopWithBreak");
+		}
+
+		if (CompactMacroName.Equals(TEXT("While"), ESearchCase::IgnoreCase) ||
+			CompactMacroName.Equals(TEXT("WhileLoop"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("WhileLoop");
+		}
+
+		return MacroName;
+	}
+}
 
 UK2Node* FSpecializedNodeCreator::CreateGetDataTableRowNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
 {
@@ -132,4 +208,97 @@ UK2Node* FSpecializedNodeCreator::CreateKnotNode(UEdGraph* Graph, const TSharedP
 	FNodeCreatorUtils::InitializeK2Node(KnotNode, Graph);
 
 	return KnotNode;
+}
+
+UK2Node* FSpecializedNodeCreator::CreateMacroInstanceNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
+{
+	if (!Graph || !Params.IsValid())
+	{
+		return nullptr;
+	}
+
+	FString MacroName;
+	if (!Params->TryGetStringField(TEXT("macro_name"), MacroName))
+	{
+		if (!Params->TryGetStringField(TEXT("target_function"), MacroName))
+		{
+			if (!Params->TryGetStringField(TEXT("macro_type"), MacroName))
+			{
+				Params->TryGetStringField(TEXT("standard_macro"), MacroName);
+			}
+		}
+	}
+	MacroName = NormalizeStandardMacroName(MacroName);
+
+	FString MacroBlueprintPath = TEXT("/Engine/EditorBlueprintResources/StandardMacros.StandardMacros");
+	if (!Params->TryGetStringField(TEXT("macro_blueprint"), MacroBlueprintPath))
+	{
+		Params->TryGetStringField(TEXT("target_blueprint"), MacroBlueprintPath);
+	}
+
+	UEdGraph* MacroGraph = ResolveMacroGraph(MacroBlueprintPath, MacroName);
+	if (!MacroGraph)
+	{
+		return nullptr;
+	}
+
+	UK2Node_MacroInstance* MacroNode = NewObject<UK2Node_MacroInstance>(Graph);
+	if (!MacroNode)
+	{
+		return nullptr;
+	}
+
+	MacroNode->SetMacroGraph(MacroGraph);
+
+	double PosX, PosY;
+	FNodeCreatorUtils::ExtractNodePosition(Params, PosX, PosY);
+	MacroNode->NodePosX = static_cast<int32>(PosX);
+	MacroNode->NodePosY = static_cast<int32>(PosY);
+
+	Graph->AddNode(MacroNode, true, false);
+	FNodeCreatorUtils::InitializeK2Node(MacroNode, Graph);
+
+	return MacroNode;
+}
+
+UK2Node* FSpecializedNodeCreator::CreateFunctionResultNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
+{
+	if (!Graph || !Params.IsValid())
+	{
+		return nullptr;
+	}
+
+	UK2Node_FunctionResult* TemplateResult = nullptr;
+	for (UEdGraphNode* ExistingNode : Graph->Nodes)
+	{
+		if (UK2Node_FunctionResult* ExistingResult = Cast<UK2Node_FunctionResult>(ExistingNode))
+		{
+			TemplateResult = ExistingResult;
+			break;
+		}
+	}
+
+	if (!TemplateResult)
+	{
+		return nullptr;
+	}
+
+	UK2Node_FunctionResult* ResultNode = NewObject<UK2Node_FunctionResult>(Graph);
+	if (!ResultNode)
+	{
+		return nullptr;
+	}
+
+	ResultNode->FunctionReference = TemplateResult->FunctionReference;
+	ResultNode->UserDefinedPins = TemplateResult->UserDefinedPins;
+
+	double PosX, PosY;
+	FNodeCreatorUtils::ExtractNodePosition(Params, PosX, PosY);
+	ResultNode->NodePosX = static_cast<int32>(PosX);
+	ResultNode->NodePosY = static_cast<int32>(PosY);
+
+	Graph->AddNode(ResultNode, true, false);
+	FNodeCreatorUtils::InitializeK2Node(ResultNode, Graph);
+
+	return ResultNode;
 }

--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/Nodes/UtilityNodes.cpp
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/Nodes/UtilityNodes.cpp
@@ -3,9 +3,99 @@
 #include "K2Node_CallFunction.h"
 #include "K2Node_Select.h"
 #include "K2Node_SpawnActorFromClass.h"
+#include "Blueprint/SlateBlueprintLibrary.h"
+#include "Blueprint/WidgetBlueprintLibrary.h"
+#include "Blueprint/WidgetLayoutLibrary.h"
 #include "EdGraphSchema_K2.h"
+#include "Engine/Blueprint.h"
+#include "Kismet/GameplayStatics.h"
+#include "Kismet/KismetInputLibrary.h"
+#include "Kismet/KismetMathLibrary.h"
 #include "Kismet/KismetSystemLibrary.h"
 #include "Json.h"
+
+namespace
+{
+UClass* ResolveFunctionOwnerClass(const FString& ClassName)
+{
+	if (ClassName.IsEmpty())
+	{
+		return nullptr;
+	}
+
+	if (UClass* TargetClass = Cast<UClass>(StaticFindObject(UClass::StaticClass(), nullptr, *ClassName)))
+	{
+		return TargetClass;
+	}
+
+	if (UClass* TargetClass = LoadObject<UClass>(nullptr, *ClassName))
+	{
+		return TargetClass;
+	}
+
+	if (UBlueprint* TargetBlueprint = LoadObject<UBlueprint>(nullptr, *ClassName))
+	{
+		return TargetBlueprint->GeneratedClass;
+	}
+
+	if (ClassName.Contains(TEXT("KismetInputLibrary")) || ClassName.Equals(TEXT("KismetInputLibrary"), ESearchCase::IgnoreCase))
+	{
+		return UKismetInputLibrary::StaticClass();
+	}
+	if (ClassName.Contains(TEXT("KismetMathLibrary")) || ClassName.Equals(TEXT("KismetMathLibrary"), ESearchCase::IgnoreCase))
+	{
+		return UKismetMathLibrary::StaticClass();
+	}
+	if (ClassName.Contains(TEXT("KismetSystemLibrary")) || ClassName.Equals(TEXT("KismetSystemLibrary"), ESearchCase::IgnoreCase))
+	{
+		return UKismetSystemLibrary::StaticClass();
+	}
+	if (ClassName.Contains(TEXT("WidgetBlueprintLibrary")) || ClassName.Equals(TEXT("WidgetBlueprintLibrary"), ESearchCase::IgnoreCase))
+	{
+		return UWidgetBlueprintLibrary::StaticClass();
+	}
+	if (ClassName.Contains(TEXT("WidgetLayoutLibrary")) || ClassName.Equals(TEXT("WidgetLayoutLibrary"), ESearchCase::IgnoreCase))
+	{
+		return UWidgetLayoutLibrary::StaticClass();
+	}
+	if (ClassName.Contains(TEXT("SlateBlueprintLibrary")) || ClassName.Equals(TEXT("SlateBlueprintLibrary"), ESearchCase::IgnoreCase))
+	{
+		return USlateBlueprintLibrary::StaticClass();
+	}
+	if (ClassName.Contains(TEXT("GameplayStatics")) || ClassName.Equals(TEXT("GameplayStatics"), ESearchCase::IgnoreCase))
+	{
+		return UGameplayStatics::StaticClass();
+	}
+
+	return nullptr;
+}
+
+UFunction* FindCommonBlueprintFunction(const FName FunctionName)
+{
+	UClass* CommonClasses[] = {
+		UKismetSystemLibrary::StaticClass(),
+		UKismetMathLibrary::StaticClass(),
+		UKismetInputLibrary::StaticClass(),
+		UWidgetBlueprintLibrary::StaticClass(),
+		UWidgetLayoutLibrary::StaticClass(),
+		USlateBlueprintLibrary::StaticClass(),
+		UGameplayStatics::StaticClass()
+	};
+
+	for (UClass* CommonClass : CommonClasses)
+	{
+		if (CommonClass)
+		{
+			if (UFunction* Function = CommonClass->FindFunctionByName(FunctionName))
+			{
+				return Function;
+			}
+		}
+	}
+
+	return nullptr;
+}
+}
 
 UK2Node* FUtilityNodeCreator::CreatePrintNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
 {
@@ -79,7 +169,16 @@ UK2Node* FUtilityNodeCreator::CreateCallFunctionNode(UEdGraph* Graph, const TSha
 	FString ClassName;
 	if (Params->TryGetStringField(TEXT("target_class"), ClassName))
 	{
-		UClass* TargetClass = Cast<UClass>(StaticFindObject(UClass::StaticClass(), nullptr, *ClassName));
+		UClass* TargetClass = ResolveFunctionOwnerClass(ClassName);
+		if (TargetClass)
+		{
+			TargetFunc = TargetClass->FindFunctionByName(FName(*TargetFunction));
+		}
+	}
+	else if (Params->TryGetStringField(TEXT("target_blueprint"), ClassName))
+	{
+		UClass* TargetClass = ResolveFunctionOwnerClass(ClassName);
+
 		if (TargetClass)
 		{
 			TargetFunc = TargetClass->FindFunctionByName(FName(*TargetFunction));
@@ -88,7 +187,12 @@ UK2Node* FUtilityNodeCreator::CreateCallFunctionNode(UEdGraph* Graph, const TSha
 	else
 	{
 		// Try common Unreal classes
-		TargetFunc = UKismetSystemLibrary::StaticClass()->FindFunctionByName(FName(*TargetFunction));
+		TargetFunc = FindCommonBlueprintFunction(FName(*TargetFunction));
+	}
+
+	if (!TargetFunc)
+	{
+		TargetFunc = FindCommonBlueprintFunction(FName(*TargetFunction));
 	}
 
 	if (!TargetFunc)

--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPBlueprintCommands.cpp
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPBlueprintCommands.cpp
@@ -27,7 +27,82 @@
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "GameFramework/Actor.h"
 #include "GameFramework/Pawn.h"
+#include "Blueprint/UserWidget.h"
+#include "Blueprint/WidgetTree.h"
+#include "Components/Widget.h"
 #include "Kismet/GameplayStatics.h"
+#include "Misc/PackageName.h"
+#include "UObject/SavePackage.h"
+#include "WidgetBlueprint.h"
+
+namespace
+{
+bool SaveBlueprintAsset(UBlueprint* Blueprint)
+{
+    if (!Blueprint)
+    {
+        return false;
+    }
+
+    Blueprint->MarkPackageDirty();
+    FKismetEditorUtilities::CompileBlueprint(Blueprint);
+
+    const FString PackageName = FPackageName::ObjectPathToPackageName(Blueprint->GetPathName());
+    const FString Filename = FPackageName::LongPackageNameToFilename(PackageName, FPackageName::GetAssetPackageExtension());
+    FSavePackageArgs SaveArgs;
+    SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+    SaveArgs.SaveFlags = SAVE_NoError;
+    return UPackage::SavePackage(Blueprint->GetOutermost(), Blueprint, *Filename, SaveArgs);
+}
+
+UClass* ResolveParentClassForBlueprint(const FString& ParentClass)
+{
+    if (ParentClass.IsEmpty())
+    {
+        return nullptr;
+    }
+
+    if (ParentClass == TEXT("UserWidget") || ParentClass == TEXT("UUserWidget") || ParentClass == TEXT("/Script/UMG.UserWidget"))
+    {
+        return UUserWidget::StaticClass();
+    }
+    if (ParentClass == TEXT("Actor") || ParentClass == TEXT("AActor") || ParentClass == TEXT("/Script/Engine.Actor"))
+    {
+        return AActor::StaticClass();
+    }
+    if (ParentClass == TEXT("Pawn") || ParentClass == TEXT("APawn") || ParentClass == TEXT("/Script/Engine.Pawn"))
+    {
+        return APawn::StaticClass();
+    }
+
+    if (UClass* LoadedClass = LoadClass<UObject>(nullptr, *ParentClass))
+    {
+        return LoadedClass;
+    }
+
+    if (UClass* FoundClass = FindObject<UClass>(nullptr, *ParentClass))
+    {
+        return FoundClass;
+    }
+
+    if (!ParentClass.Contains(TEXT(".")) && !ParentClass.StartsWith(TEXT("/Script/")))
+    {
+        const FString EngineClassPath = FString::Printf(TEXT("/Script/Engine.%s"), *ParentClass);
+        if (UClass* EngineClass = LoadClass<UObject>(nullptr, *EngineClassPath))
+        {
+            return EngineClass;
+        }
+
+        const FString UMGClassPath = FString::Printf(TEXT("/Script/UMG.%s"), *ParentClass);
+        if (UClass* UMGClass = LoadClass<UObject>(nullptr, *UMGClassPath))
+        {
+            return UMGClass;
+        }
+    }
+
+    return nullptr;
+}
+}
 
 FEpicUnrealMCPBlueprintCommands::FEpicUnrealMCPBlueprintCommands()
 {
@@ -38,6 +113,14 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintCommands::HandleCommand(const FSt
     if (CommandType == TEXT("create_blueprint"))
     {
         return HandleCreateBlueprint(Params);
+    }
+    else if (CommandType == TEXT("reparent_blueprint"))
+    {
+        return HandleReparentBlueprint(Params);
+    }
+    else if (CommandType == TEXT("set_widget_is_variable"))
+    {
+        return HandleSetWidgetIsVariable(Params);
     }
     else if (CommandType == TEXT("add_component_to_blueprint"))
     {
@@ -198,6 +281,158 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintCommands::HandleCreateBlueprint(c
     }
 
     return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Failed to create blueprint"));
+}
+
+TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintCommands::HandleReparentBlueprint(const TSharedPtr<FJsonObject>& Params)
+{
+    FString BlueprintPath;
+    if (!Params->TryGetStringField(TEXT("blueprint_path"), BlueprintPath)
+        && !Params->TryGetStringField(TEXT("blueprint_name"), BlueprintPath))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'blueprint_path' or 'blueprint_name' parameter"));
+    }
+
+    FString ParentClassName;
+    if (!Params->TryGetStringField(TEXT("parent_class"), ParentClassName))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'parent_class' parameter"));
+    }
+
+    UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *BlueprintPath);
+    if (!Blueprint)
+    {
+        Blueprint = FEpicUnrealMCPCommonUtils::FindBlueprint(BlueprintPath);
+    }
+    if (!Blueprint)
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Blueprint not found: %s"), *BlueprintPath));
+    }
+
+    UClass* NewParentClass = ResolveParentClassForBlueprint(ParentClassName);
+    if (!NewParentClass)
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Parent class not found: %s"), *ParentClassName));
+    }
+    if (!FKismetEditorUtilities::CanCreateBlueprintOfClass(NewParentClass))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Class cannot be used as a Blueprint parent: %s"), *NewParentClass->GetName()));
+    }
+
+    const FString OldParentName = Blueprint->ParentClass ? Blueprint->ParentClass->GetName() : TEXT("None");
+    Blueprint->Modify();
+    Blueprint->ParentClass = NewParentClass;
+    FBlueprintEditorUtils::RefreshAllNodes(Blueprint);
+    FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
+    const bool bSaved = SaveBlueprintAsset(Blueprint);
+
+    TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+    Result->SetBoolField(TEXT("success"), true);
+    Result->SetStringField(TEXT("blueprint_path"), Blueprint->GetPathName());
+    Result->SetStringField(TEXT("old_parent_class"), OldParentName);
+    Result->SetStringField(TEXT("new_parent_class"), NewParentClass->GetName());
+    Result->SetBoolField(TEXT("saved"), bSaved);
+    return Result;
+}
+
+TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintCommands::HandleSetWidgetIsVariable(const TSharedPtr<FJsonObject>& Params)
+{
+    FString BlueprintPath;
+    if (!Params->TryGetStringField(TEXT("blueprint_path"), BlueprintPath)
+        && !Params->TryGetStringField(TEXT("blueprint_name"), BlueprintPath))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'blueprint_path' or 'blueprint_name' parameter"));
+    }
+
+    bool bIsVariable = true;
+    Params->TryGetBoolField(TEXT("is_variable"), bIsVariable);
+
+    TArray<FString> WidgetNames;
+    FString SingleWidgetName;
+    if (Params->TryGetStringField(TEXT("widget_name"), SingleWidgetName))
+    {
+        WidgetNames.Add(SingleWidgetName);
+    }
+
+    const TArray<TSharedPtr<FJsonValue>>* WidgetNameValues = nullptr;
+    if (Params->TryGetArrayField(TEXT("widget_names"), WidgetNameValues))
+    {
+        for (const TSharedPtr<FJsonValue>& Value : *WidgetNameValues)
+        {
+            FString WidgetName;
+            if (Value.IsValid() && Value->TryGetString(WidgetName) && !WidgetName.IsEmpty())
+            {
+                WidgetNames.Add(WidgetName);
+            }
+        }
+    }
+
+    if (WidgetNames.Num() == 0)
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'widget_name' or non-empty 'widget_names' parameter"));
+    }
+
+    UWidgetBlueprint* WidgetBlueprint = Cast<UWidgetBlueprint>(LoadObject<UBlueprint>(nullptr, *BlueprintPath));
+    if (!WidgetBlueprint)
+    {
+        WidgetBlueprint = Cast<UWidgetBlueprint>(FEpicUnrealMCPCommonUtils::FindBlueprint(BlueprintPath));
+    }
+    if (!WidgetBlueprint || !WidgetBlueprint->WidgetTree)
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Widget Blueprint not found: %s"), *BlueprintPath));
+    }
+
+    TArray<TSharedPtr<FJsonValue>> ChangedWidgets;
+    TArray<TSharedPtr<FJsonValue>> MissingWidgets;
+    TArray<TSharedPtr<FJsonValue>> AvailableWidgets;
+
+    TArray<UWidget*> WidgetsInTree;
+    WidgetBlueprint->WidgetTree->ForEachWidget([&WidgetsInTree, &AvailableWidgets](UWidget* Widget)
+    {
+        if (Widget)
+        {
+            WidgetsInTree.Add(Widget);
+            AvailableWidgets.Add(MakeShared<FJsonValueString>(Widget->GetName()));
+        }
+    });
+
+    WidgetBlueprint->Modify();
+    for (const FString& WidgetName : WidgetNames)
+    {
+        UWidget* Widget = WidgetBlueprint->WidgetTree->FindWidget(FName(*WidgetName));
+        if (!Widget)
+        {
+            for (UWidget* CandidateWidget : WidgetsInTree)
+            {
+                if (CandidateWidget && CandidateWidget->GetName().Equals(WidgetName, ESearchCase::IgnoreCase))
+                {
+                    Widget = CandidateWidget;
+                    break;
+                }
+            }
+        }
+        if (!Widget)
+        {
+            MissingWidgets.Add(MakeShared<FJsonValueString>(WidgetName));
+            continue;
+        }
+
+        Widget->Modify();
+        Widget->bIsVariable = bIsVariable;
+        ChangedWidgets.Add(MakeShared<FJsonValueString>(WidgetName));
+    }
+
+    FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WidgetBlueprint);
+    const bool bSaved = SaveBlueprintAsset(WidgetBlueprint);
+
+    TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+    Result->SetBoolField(TEXT("success"), true);
+    Result->SetStringField(TEXT("blueprint_path"), WidgetBlueprint->GetPathName());
+    Result->SetBoolField(TEXT("is_variable"), bIsVariable);
+    Result->SetArrayField(TEXT("changed_widgets"), ChangedWidgets);
+    Result->SetArrayField(TEXT("missing_widgets"), MissingWidgets);
+    Result->SetArrayField(TEXT("available_widgets"), AvailableWidgets);
+    Result->SetBoolField(TEXT("saved"), bSaved);
+    return Result;
 }
 
 TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintCommands::HandleAddComponentToBlueprint(const TSharedPtr<FJsonObject>& Params)
@@ -392,10 +627,19 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintCommands::HandleCompileBlueprint(
 
     // Compile the blueprint
     FKismetEditorUtilities::CompileBlueprint(Blueprint);
+    Blueprint->MarkPackageDirty();
+
+    const FString PackageName = FPackageName::ObjectPathToPackageName(Blueprint->GetPathName());
+    const FString Filename = FPackageName::LongPackageNameToFilename(PackageName, FPackageName::GetAssetPackageExtension());
+    FSavePackageArgs SaveArgs;
+    SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+    SaveArgs.SaveFlags = SAVE_NoError;
+    const bool bSaved = UPackage::SavePackage(Blueprint->GetOutermost(), Blueprint, *Filename, SaveArgs);
 
     TSharedPtr<FJsonObject> ResultObj = MakeShared<FJsonObject>();
     ResultObj->SetStringField(TEXT("name"), BlueprintName);
     ResultObj->SetBoolField(TEXT("compiled"), true);
+    ResultObj->SetBoolField(TEXT("saved"), bSaved);
     return ResultObj;
 }
 
@@ -1395,6 +1639,15 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintCommands::HandleAnalyzeBlueprintG
                         PinObj->SetStringField(TEXT("type"), Pin->PinType.PinCategory.ToString());
                         PinObj->SetStringField(TEXT("direction"), Pin->Direction == EGPD_Input ? TEXT("Input") : TEXT("Output"));
                         PinObj->SetNumberField(TEXT("connections"), Pin->LinkedTo.Num());
+                        PinObj->SetStringField(TEXT("default_value"), Pin->DefaultValue);
+                        if (Pin->DefaultObject)
+                        {
+                            PinObj->SetStringField(TEXT("default_object"), Pin->DefaultObject->GetPathName());
+                        }
+                        if (!Pin->DefaultTextValue.IsEmpty())
+                        {
+                            PinObj->SetStringField(TEXT("default_text"), Pin->DefaultTextValue.ToString());
+                        }
                         
                         // Record connections for this pin
                         for (UEdGraphPin* LinkedPin : Pin->LinkedTo)

--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPBlueprintGraphCommands.cpp
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPBlueprintGraphCommands.cpp
@@ -8,6 +8,259 @@
 #include "Commands/BlueprintGraph/NodePropertyManager.h"
 #include "Commands/BlueprintGraph/Function/FunctionManager.h"
 #include "Commands/BlueprintGraph/Function/FunctionIO.h"
+#include "Engine/Blueprint.h"
+#include "EdGraph/EdGraph.h"
+#include "EdGraph/EdGraphNode.h"
+#include "EdGraphSchema_K2.h"
+#include "K2Node_Event.h"
+#include "K2Node_FunctionEntry.h"
+#include "K2Node_FunctionResult.h"
+#include "Kismet2/BlueprintEditorUtils.h"
+#include "Kismet2/KismetEditorUtilities.h"
+#include "Misc/PackageName.h"
+#include "Misc/Paths.h"
+#include "UObject/SavePackage.h"
+
+namespace
+{
+TSharedPtr<FJsonObject> CloneJsonObject(const TSharedPtr<FJsonObject>& Source)
+{
+    TSharedPtr<FJsonObject> Clone = MakeShared<FJsonObject>();
+    if (Source.IsValid())
+    {
+        Clone->Values = Source->Values;
+    }
+    return Clone;
+}
+
+void CopyJsonFieldIfMissing(const TSharedPtr<FJsonObject>& Source, const TCHAR* FieldName, const TSharedPtr<FJsonObject>& Target)
+{
+    if (!Source.IsValid() || !Target.IsValid() || Target->HasField(FieldName))
+    {
+        return;
+    }
+
+    const TSharedPtr<FJsonValue>* Value = Source->Values.Find(FieldName);
+    if (Value && Value->IsValid())
+    {
+        Target->SetField(FieldName, *Value);
+    }
+}
+
+bool JsonBoolWithDefault(const TSharedPtr<FJsonObject>& Object, const TCHAR* FieldName, const bool DefaultValue)
+{
+    bool Value = DefaultValue;
+    if (Object.IsValid())
+    {
+        Object->TryGetBoolField(FieldName, Value);
+    }
+    return Value;
+}
+
+UBlueprint* LoadGraphCommandBlueprint(const FString& BlueprintName)
+{
+    if (UBlueprint* Blueprint = FEpicUnrealMCPCommonUtils::FindBlueprint(BlueprintName))
+    {
+        return Blueprint;
+    }
+
+    FString BlueprintPath = BlueprintName;
+    if (!BlueprintPath.StartsWith(TEXT("/")))
+    {
+        BlueprintPath = TEXT("/Game/Blueprints/") + BlueprintPath;
+    }
+    if (!BlueprintPath.Contains(TEXT(".")))
+    {
+        BlueprintPath += TEXT(".") + FPaths::GetBaseFilename(BlueprintPath);
+    }
+
+    return LoadObject<UBlueprint>(nullptr, *BlueprintPath);
+}
+
+UEdGraph* FindGraphForBatchCommand(UBlueprint* Blueprint, const FString& FunctionName)
+{
+    if (!Blueprint)
+    {
+        return nullptr;
+    }
+
+    if (FunctionName.IsEmpty() || FunctionName.Equals(TEXT("EventGraph"), ESearchCase::IgnoreCase))
+    {
+        return Blueprint->UbergraphPages.Num() > 0 ? Blueprint->UbergraphPages[0] : nullptr;
+    }
+
+    for (UEdGraph* FunctionGraph : Blueprint->FunctionGraphs)
+    {
+        if (FunctionGraph &&
+            (FunctionGraph->GetName().Equals(FunctionName, ESearchCase::IgnoreCase) ||
+             FunctionGraph->GetFName().ToString().Equals(FunctionName, ESearchCase::IgnoreCase)))
+        {
+            return FunctionGraph;
+        }
+    }
+
+    return nullptr;
+}
+
+TSharedPtr<FJsonObject> ClearGraphBody(const TSharedPtr<FJsonObject>& Params)
+{
+    FString BlueprintName;
+    if (!Params->TryGetStringField(TEXT("blueprint_name"), BlueprintName))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'blueprint_name' parameter"));
+    }
+
+    FString FunctionName;
+    Params->TryGetStringField(TEXT("function_name"), FunctionName);
+
+    UBlueprint* Blueprint = LoadGraphCommandBlueprint(BlueprintName);
+    if (!Blueprint)
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Blueprint not found: %s"), *BlueprintName));
+    }
+
+    UEdGraph* Graph = FindGraphForBatchCommand(Blueprint, FunctionName);
+    if (!Graph)
+    {
+        const FString ErrorMessage = FunctionName.IsEmpty()
+            ? FString(TEXT("Blueprint has no event graph"))
+            : FString::Printf(TEXT("Function graph not found: %s"), *FunctionName);
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(ErrorMessage);
+    }
+
+    const bool bKeepFunctionEntry = JsonBoolWithDefault(Params, TEXT("keep_function_entry"), true);
+    const bool bKeepFunctionResult = JsonBoolWithDefault(Params, TEXT("keep_function_result"), true);
+    const bool bKeepEventNodes = JsonBoolWithDefault(Params, TEXT("keep_event_nodes"), false);
+    const bool bBreakKeptLinks = JsonBoolWithDefault(Params, TEXT("break_kept_links"), true);
+
+    Blueprint->Modify();
+    Graph->Modify();
+
+    int32 RemovedCount = 0;
+    int32 KeptCount = 0;
+    TArray<UEdGraphNode*> Nodes = Graph->Nodes;
+
+    for (UEdGraphNode* Node : Nodes)
+    {
+        if (!Node)
+        {
+            continue;
+        }
+
+        const bool bKeepNode =
+            (bKeepFunctionEntry && Cast<UK2Node_FunctionEntry>(Node)) ||
+            (bKeepFunctionResult && Cast<UK2Node_FunctionResult>(Node)) ||
+            (bKeepEventNodes && Cast<UK2Node_Event>(Node));
+
+        Node->Modify();
+        if (bKeepNode)
+        {
+            if (bBreakKeptLinks)
+            {
+                Node->BreakAllNodeLinks();
+            }
+            ++KeptCount;
+            continue;
+        }
+
+        Node->BreakAllNodeLinks();
+        Graph->RemoveNode(Node);
+        ++RemovedCount;
+    }
+
+    Graph->NotifyGraphChanged();
+    FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
+
+    TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+    Result->SetBoolField(TEXT("success"), true);
+    Result->SetNumberField(TEXT("removed_nodes"), RemovedCount);
+    Result->SetNumberField(TEXT("kept_nodes"), KeptCount);
+    Result->SetStringField(TEXT("graph_name"), Graph->GetName());
+    return Result;
+}
+
+FString ResolveNodeId(const TMap<FString, FString>& Aliases, const FString& Reference)
+{
+    if (const FString* NodeId = Aliases.Find(Reference))
+    {
+        return *NodeId;
+    }
+    return Reference;
+}
+
+bool TryGetAnyStringField(const TSharedPtr<FJsonObject>& Object, const TArray<FString>& FieldNames, FString& OutValue)
+{
+    if (!Object.IsValid())
+    {
+        return false;
+    }
+
+    for (const FString& FieldName : FieldNames)
+    {
+        if (Object->TryGetStringField(FieldName, OutValue))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+TSharedPtr<FJsonObject> BuildAddNodeParams(const TSharedPtr<FJsonObject>& BatchParams, const TSharedPtr<FJsonObject>& Operation)
+{
+    TSharedPtr<FJsonObject> AddParams = MakeShared<FJsonObject>();
+    CopyJsonFieldIfMissing(Operation, TEXT("blueprint_name"), AddParams);
+    CopyJsonFieldIfMissing(BatchParams, TEXT("blueprint_name"), AddParams);
+    CopyJsonFieldIfMissing(Operation, TEXT("node_type"), AddParams);
+
+    const TSharedPtr<FJsonObject>* NodeParamsObject = nullptr;
+    TSharedPtr<FJsonObject> NodeParams = MakeShared<FJsonObject>();
+    if (Operation->TryGetObjectField(TEXT("node_params"), NodeParamsObject) && NodeParamsObject && NodeParamsObject->IsValid())
+    {
+        NodeParams = CloneJsonObject(*NodeParamsObject);
+    }
+
+    const TSet<FString> ReservedFields =
+    {
+        TEXT("op"),
+        TEXT("command"),
+        TEXT("alias"),
+        TEXT("blueprint_name"),
+        TEXT("node_type"),
+        TEXT("node_params")
+    };
+
+    for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : Operation->Values)
+    {
+        if (!ReservedFields.Contains(Pair.Key) && !NodeParams->HasField(Pair.Key))
+        {
+            NodeParams->SetField(Pair.Key, Pair.Value);
+        }
+    }
+
+    CopyJsonFieldIfMissing(BatchParams, TEXT("function_name"), NodeParams);
+    AddParams->SetObjectField(TEXT("node_params"), NodeParams);
+    return AddParams;
+}
+
+bool SaveGraphBlueprint(UBlueprint* Blueprint)
+{
+    if (!Blueprint)
+    {
+        return false;
+    }
+
+    Blueprint->MarkPackageDirty();
+    FKismetEditorUtilities::CompileBlueprint(Blueprint);
+
+    const FString PackageName = FPackageName::ObjectPathToPackageName(Blueprint->GetPathName());
+    const FString Filename = FPackageName::LongPackageNameToFilename(PackageName, FPackageName::GetAssetPackageExtension());
+    FSavePackageArgs SaveArgs;
+    SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+    SaveArgs.SaveFlags = SAVE_NoError;
+    return UPackage::SavePackage(Blueprint->GetOutermost(), Blueprint, *Filename, SaveArgs);
+}
+}
 
 FEpicUnrealMCPBlueprintGraphCommands::FEpicUnrealMCPBlueprintGraphCommands()
 {
@@ -23,9 +276,52 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleCommand(cons
     {
         return HandleAddBlueprintNode(Params);
     }
+    else if (CommandType == TEXT("execute_blueprint_graph_batch") ||
+             CommandType == TEXT("batch_blueprint_graph_commands"))
+    {
+        return HandleBatchGraphCommands(Params);
+    }
+    else if (CommandType == TEXT("add_set_fields_in_struct_node") ||
+             CommandType == TEXT("add_set_struct_fields_node"))
+    {
+        return HandleAddBlueprintNodeAlias(Params, TEXT("SetFieldsInStruct"));
+    }
+    else if (CommandType == TEXT("add_macro_instance_node") ||
+             CommandType == TEXT("add_standard_macro_node"))
+    {
+        return HandleAddBlueprintNodeAlias(Params, TEXT("MacroInstance"));
+    }
+    else if (CommandType == TEXT("add_for_each_loop_node"))
+    {
+        return HandleAddBlueprintNodeAlias(Params, TEXT("ForEachLoop"));
+    }
+    else if (CommandType == TEXT("add_for_each_loop_with_break_node"))
+    {
+        return HandleAddBlueprintNodeAlias(Params, TEXT("ForEachLoopWithBreak"));
+    }
+    else if (CommandType == TEXT("add_reverse_for_each_loop_node"))
+    {
+        return HandleAddBlueprintNodeAlias(Params, TEXT("ReverseForEachLoop"));
+    }
+    else if (CommandType == TEXT("add_for_loop_node"))
+    {
+        return HandleAddBlueprintNodeAlias(Params, TEXT("ForLoop"));
+    }
+    else if (CommandType == TEXT("add_for_loop_with_break_node"))
+    {
+        return HandleAddBlueprintNodeAlias(Params, TEXT("ForLoopWithBreak"));
+    }
+    else if (CommandType == TEXT("add_while_loop_node"))
+    {
+        return HandleAddBlueprintNodeAlias(Params, TEXT("WhileLoop"));
+    }
     else if (CommandType == TEXT("connect_nodes"))
     {
         return HandleConnectNodes(Params);
+    }
+    else if (CommandType == TEXT("break_pin_links"))
+    {
+        return HandleBreakPinLinks(Params);
     }
     else if (CommandType == TEXT("create_variable"))
     {
@@ -50,6 +346,10 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleCommand(cons
     else if (CommandType == TEXT("create_function"))
     {
         return HandleCreateFunction(Params);
+    }
+    else if (CommandType == TEXT("create_override_function"))
+    {
+        return HandleCreateOverrideFunction(Params);
     }
     else if (CommandType == TEXT("add_function_input"))
     {
@@ -92,6 +392,20 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleAddBlueprint
     return FBlueprintNodeManager::AddNode(Params);
 }
 
+TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleAddBlueprintNodeAlias(const TSharedPtr<FJsonObject>& Params, const FString& NodeType)
+{
+    if (!Params.IsValid())
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Invalid parameters"));
+    }
+
+    TSharedPtr<FJsonObject> AliasedParams = MakeShared<FJsonObject>();
+    AliasedParams->Values = Params->Values;
+    AliasedParams->SetStringField(TEXT("node_type"), NodeType);
+
+    return HandleAddBlueprintNode(AliasedParams);
+}
+
 TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleConnectNodes(const TSharedPtr<FJsonObject>& Params)
 {
     // Get required parameters
@@ -130,6 +444,33 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleConnectNodes
 
     // Use the BPConnector to connect the nodes
     return FBPConnector::ConnectNodes(Params);
+}
+
+TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleBreakPinLinks(const TSharedPtr<FJsonObject>& Params)
+{
+    FString BlueprintName;
+    if (!Params->TryGetStringField(TEXT("blueprint_name"), BlueprintName))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'blueprint_name' parameter"));
+    }
+
+    FString NodeId;
+    if (!Params->TryGetStringField(TEXT("node_id"), NodeId))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'node_id' parameter"));
+    }
+
+    FString PinName;
+    if (!Params->TryGetStringField(TEXT("pin_name"), PinName))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'pin_name' parameter"));
+    }
+
+    UE_LOG(LogTemp, Display,
+        TEXT("FEpicUnrealMCPBlueprintGraphCommands::HandleBreakPinLinks: Breaking links on %s.%s in blueprint '%s'"),
+        *NodeId, *PinName, *BlueprintName);
+
+    return FBPConnector::BreakPinLinks(Params);
 }
 
 TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleCreateVariable(const TSharedPtr<FJsonObject>& Params)
@@ -289,6 +630,67 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleCreateFuncti
     return FFunctionManager::CreateFunction(Params);
 }
 
+TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleCreateOverrideFunction(const TSharedPtr<FJsonObject>& Params)
+{
+    FString BlueprintName;
+    if (!Params->TryGetStringField(TEXT("blueprint_name"), BlueprintName))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'blueprint_name' parameter"));
+    }
+
+    FString FunctionName;
+    if (!Params->TryGetStringField(TEXT("function_name"), FunctionName))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'function_name' parameter"));
+    }
+
+    UBlueprint* Blueprint = FEpicUnrealMCPCommonUtils::FindBlueprint(BlueprintName);
+    if (!Blueprint)
+    {
+        Blueprint = LoadObject<UBlueprint>(nullptr, *BlueprintName);
+    }
+    if (!Blueprint)
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Blueprint not found: %s"), *BlueprintName));
+    }
+
+    UFunction* OverrideFunction = nullptr;
+    UClass* OverrideClass = FBlueprintEditorUtils::GetOverrideFunctionClass(Blueprint, FName(*FunctionName), &OverrideFunction);
+    if (!OverrideClass || !OverrideFunction)
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Override function not found: %s"), *FunctionName));
+    }
+
+    for (UEdGraph* ExistingGraph : Blueprint->FunctionGraphs)
+    {
+        if (ExistingGraph && ExistingGraph->GetFName() == FName(*FunctionName))
+        {
+            TSharedPtr<FJsonObject> ExistingResult = MakeShared<FJsonObject>();
+            ExistingResult->SetBoolField(TEXT("success"), true);
+            ExistingResult->SetBoolField(TEXT("created"), false);
+            ExistingResult->SetStringField(TEXT("function_name"), FunctionName);
+            ExistingResult->SetStringField(TEXT("graph_name"), ExistingGraph->GetName());
+            ExistingResult->SetStringField(TEXT("signature_class"), OverrideClass->GetName());
+            return ExistingResult;
+        }
+    }
+
+    Blueprint->Modify();
+    UEdGraph* NewGraph = FBlueprintEditorUtils::CreateNewGraph(Blueprint, FName(*FunctionName), UEdGraph::StaticClass(), UEdGraphSchema_K2::StaticClass());
+    FBlueprintEditorUtils::AddFunctionGraph(Blueprint, NewGraph, false, OverrideClass);
+    FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
+    const bool bSaved = SaveGraphBlueprint(Blueprint);
+
+    TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+    Result->SetBoolField(TEXT("success"), true);
+    Result->SetBoolField(TEXT("created"), true);
+    Result->SetBoolField(TEXT("saved"), bSaved);
+    Result->SetStringField(TEXT("function_name"), FunctionName);
+    Result->SetStringField(TEXT("graph_name"), NewGraph ? NewGraph->GetName() : FunctionName);
+    Result->SetStringField(TEXT("signature_class"), OverrideClass->GetName());
+    return Result;
+}
+
 TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleAddFunctionInput(const TSharedPtr<FJsonObject>& Params)
 {
     FString BlueprintName;
@@ -385,4 +787,272 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleRenameFuncti
         *OldFunctionName, *NewFunctionName, *BlueprintName);
 
     return FFunctionManager::RenameFunction(Params);
+}
+
+TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleBatchGraphCommands(const TSharedPtr<FJsonObject>& Params)
+{
+    if (!Params.IsValid())
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Invalid parameters"));
+    }
+
+    const TArray<TSharedPtr<FJsonValue>>* Operations = nullptr;
+    if (!Params->TryGetArrayField(TEXT("operations"), Operations))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'operations' array"));
+    }
+
+    const bool bStopOnError = JsonBoolWithDefault(Params, TEXT("stop_on_error"), true);
+    TMap<FString, FString> NodeAliases;
+    TArray<TSharedPtr<FJsonValue>> Results;
+    bool bAllSucceeded = true;
+
+    for (int32 Index = 0; Index < Operations->Num(); ++Index)
+    {
+        TSharedPtr<FJsonObject> Operation = (*Operations)[Index].IsValid() ? (*Operations)[Index]->AsObject() : nullptr;
+        TSharedPtr<FJsonObject> OperationResult = nullptr;
+        FString OperationName;
+
+        if (!Operation.IsValid())
+        {
+            OperationResult = FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Operation must be a JSON object"));
+        }
+        else if (!Operation->TryGetStringField(TEXT("op"), OperationName) &&
+                 !Operation->TryGetStringField(TEXT("command"), OperationName))
+        {
+            OperationResult = FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Operation is missing 'op' or 'command'"));
+        }
+        else if (OperationName.Equals(TEXT("add_node"), ESearchCase::IgnoreCase) ||
+                 OperationName.Equals(TEXT("add_blueprint_node"), ESearchCase::IgnoreCase))
+        {
+            OperationResult = HandleAddBlueprintNode(BuildAddNodeParams(Params, Operation));
+
+            bool bOperationSuccess = false;
+            if (OperationResult.IsValid() && OperationResult->TryGetBoolField(TEXT("success"), bOperationSuccess) && bOperationSuccess)
+            {
+                FString Alias;
+                FString NodeId;
+                if (Operation->TryGetStringField(TEXT("alias"), Alias) && OperationResult->TryGetStringField(TEXT("node_id"), NodeId))
+                {
+                    NodeAliases.Add(Alias, NodeId);
+                }
+            }
+        }
+        else if (OperationName.Equals(TEXT("connect"), ESearchCase::IgnoreCase) ||
+                 OperationName.Equals(TEXT("connect_nodes"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> ConnectParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), ConnectParams);
+            CopyJsonFieldIfMissing(Params, TEXT("function_name"), ConnectParams);
+
+            FString SourceReference;
+            FString TargetReference;
+            FString SourcePin;
+            FString TargetPin;
+            if (TryGetAnyStringField(Operation, { TEXT("from"), TEXT("source"), TEXT("source_node"), TEXT("source_node_id") }, SourceReference))
+            {
+                ConnectParams->SetStringField(TEXT("source_node_id"), ResolveNodeId(NodeAliases, SourceReference));
+            }
+            if (TryGetAnyStringField(Operation, { TEXT("to"), TEXT("target"), TEXT("target_node"), TEXT("target_node_id") }, TargetReference))
+            {
+                ConnectParams->SetStringField(TEXT("target_node_id"), ResolveNodeId(NodeAliases, TargetReference));
+            }
+            if (TryGetAnyStringField(Operation, { TEXT("from_pin"), TEXT("source_pin"), TEXT("source_pin_name") }, SourcePin))
+            {
+                ConnectParams->SetStringField(TEXT("source_pin_name"), SourcePin);
+            }
+            if (TryGetAnyStringField(Operation, { TEXT("to_pin"), TEXT("target_pin"), TEXT("target_pin_name") }, TargetPin))
+            {
+                ConnectParams->SetStringField(TEXT("target_pin_name"), TargetPin);
+            }
+            if (!ConnectParams->HasField(TEXT("skip_compile")))
+            {
+                ConnectParams->SetBoolField(TEXT("skip_compile"), true);
+            }
+
+            OperationResult = HandleConnectNodes(ConnectParams);
+        }
+        else if (OperationName.Equals(TEXT("set_property"), ESearchCase::IgnoreCase) ||
+                 OperationName.Equals(TEXT("set_node_property"), ESearchCase::IgnoreCase) ||
+                 OperationName.Equals(TEXT("set_pin_default"), ESearchCase::IgnoreCase) ||
+                 OperationName.Equals(TEXT("set_pin_default_object"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> PropertyParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), PropertyParams);
+            CopyJsonFieldIfMissing(Params, TEXT("function_name"), PropertyParams);
+
+            FString NodeReference;
+            if (TryGetAnyStringField(Operation, { TEXT("node"), TEXT("node_id") }, NodeReference))
+            {
+                PropertyParams->SetStringField(TEXT("node_id"), ResolveNodeId(NodeAliases, NodeReference));
+            }
+
+            if (OperationName.Equals(TEXT("set_pin_default"), ESearchCase::IgnoreCase) ||
+                OperationName.Equals(TEXT("set_pin_default_object"), ESearchCase::IgnoreCase))
+            {
+                FString PinName;
+                if (Operation->TryGetStringField(TEXT("pin"), PinName))
+                {
+                    PropertyParams->SetStringField(TEXT("property_name"),
+                        OperationName.Equals(TEXT("set_pin_default_object"), ESearchCase::IgnoreCase)
+                            ? FString::Printf(TEXT("pin_default_object:%s"), *PinName)
+                            : FString::Printf(TEXT("pin_default:%s"), *PinName));
+                }
+
+                if (!PropertyParams->HasField(TEXT("property_value")))
+                {
+                    if (TSharedPtr<FJsonValue> Value = Operation->TryGetField(TEXT("value")))
+                    {
+                        PropertyParams->SetField(TEXT("property_value"), Value);
+                    }
+                }
+            }
+
+            OperationResult = HandleSetNodeProperty(PropertyParams);
+        }
+        else if (OperationName.Equals(TEXT("break_pin_links"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> BreakParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), BreakParams);
+            CopyJsonFieldIfMissing(Params, TEXT("function_name"), BreakParams);
+
+            FString NodeReference;
+            if (TryGetAnyStringField(Operation, { TEXT("node"), TEXT("node_id") }, NodeReference))
+            {
+                BreakParams->SetStringField(TEXT("node_id"), ResolveNodeId(NodeAliases, NodeReference));
+            }
+
+            OperationResult = HandleBreakPinLinks(BreakParams);
+        }
+        else if (OperationName.Equals(TEXT("delete_node"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> DeleteParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), DeleteParams);
+            CopyJsonFieldIfMissing(Params, TEXT("function_name"), DeleteParams);
+
+            FString NodeReference;
+            if (TryGetAnyStringField(Operation, { TEXT("node"), TEXT("node_id") }, NodeReference))
+            {
+                DeleteParams->SetStringField(TEXT("node_id"), ResolveNodeId(NodeAliases, NodeReference));
+            }
+
+            OperationResult = HandleDeleteNode(DeleteParams);
+        }
+        else if (OperationName.Equals(TEXT("clear_graph"), ESearchCase::IgnoreCase) ||
+                 OperationName.Equals(TEXT("clear_graph_body"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> ClearParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), ClearParams);
+            CopyJsonFieldIfMissing(Params, TEXT("function_name"), ClearParams);
+            OperationResult = ClearGraphBody(ClearParams);
+        }
+        else if (OperationName.Equals(TEXT("create_variable"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> CreateParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), CreateParams);
+            OperationResult = HandleCreateVariable(CreateParams);
+        }
+        else if (OperationName.Equals(TEXT("set_blueprint_variable_properties"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> VariableParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), VariableParams);
+            OperationResult = HandleSetVariableProperties(VariableParams);
+        }
+        else if (OperationName.Equals(TEXT("create_function"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> FunctionParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), FunctionParams);
+            OperationResult = HandleCreateFunction(FunctionParams);
+        }
+        else if (OperationName.Equals(TEXT("create_override_function"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> FunctionParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), FunctionParams);
+            OperationResult = HandleCreateOverrideFunction(FunctionParams);
+        }
+        else if (OperationName.Equals(TEXT("add_function_input"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> InputParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), InputParams);
+            OperationResult = HandleAddFunctionInput(InputParams);
+        }
+        else if (OperationName.Equals(TEXT("add_function_output"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> OutputParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), OutputParams);
+            OperationResult = HandleAddFunctionOutput(OutputParams);
+        }
+        else
+        {
+            OperationResult = FEpicUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Unsupported batch operation: %s"), *OperationName));
+        }
+
+        bool bOperationSuccess = false;
+        if (!OperationResult.IsValid() || !OperationResult->TryGetBoolField(TEXT("success"), bOperationSuccess) || !bOperationSuccess)
+        {
+            bAllSucceeded = false;
+        }
+
+        TSharedPtr<FJsonObject> WrappedResult = MakeShared<FJsonObject>();
+        WrappedResult->SetNumberField(TEXT("index"), Index);
+        WrappedResult->SetStringField(TEXT("op"), OperationName);
+        WrappedResult->SetBoolField(TEXT("success"), bOperationSuccess);
+        if (OperationResult.IsValid())
+        {
+            WrappedResult->SetObjectField(TEXT("result"), OperationResult);
+            FString ErrorMessage;
+            if (!bOperationSuccess && OperationResult->TryGetStringField(TEXT("error"), ErrorMessage))
+            {
+                WrappedResult->SetStringField(TEXT("error"), ErrorMessage);
+            }
+        }
+        Results.Add(MakeShared<FJsonValueObject>(WrappedResult));
+
+        if (!bOperationSuccess && bStopOnError)
+        {
+            break;
+        }
+    }
+
+    bool bCompile = true;
+    bool bSave = true;
+    Params->TryGetBoolField(TEXT("compile"), bCompile);
+    Params->TryGetBoolField(TEXT("save"), bSave);
+
+    bool bSaved = false;
+    bool bCompiled = false;
+    FString BlueprintName;
+    if ((bCompile || bSave) && Params->TryGetStringField(TEXT("blueprint_name"), BlueprintName))
+    {
+        if (UBlueprint* Blueprint = LoadGraphCommandBlueprint(BlueprintName))
+        {
+            if (bSave)
+            {
+                bSaved = SaveGraphBlueprint(Blueprint);
+                bCompiled = true;
+            }
+            else if (bCompile)
+            {
+                FKismetEditorUtilities::CompileBlueprint(Blueprint);
+                bCompiled = true;
+            }
+        }
+    }
+
+    TSharedPtr<FJsonObject> Response = MakeShared<FJsonObject>();
+    Response->SetBoolField(TEXT("success"), bAllSucceeded);
+    Response->SetArrayField(TEXT("results"), Results);
+    Response->SetBoolField(TEXT("compiled"), bCompiled);
+    Response->SetBoolField(TEXT("saved"), bSaved);
+
+    TArray<TSharedPtr<FJsonValue>> AliasResults;
+    for (const TPair<FString, FString>& Pair : NodeAliases)
+    {
+        TSharedPtr<FJsonObject> AliasObject = MakeShared<FJsonObject>();
+        AliasObject->SetStringField(TEXT("alias"), Pair.Key);
+        AliasObject->SetStringField(TEXT("node_id"), Pair.Value);
+        AliasResults.Add(MakeShared<FJsonValueObject>(AliasObject));
+    }
+    Response->SetArrayField(TEXT("aliases"), AliasResults);
+    return Response;
 }

--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/EpicUnrealMCPBridge.cpp
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/EpicUnrealMCPBridge.cpp
@@ -229,6 +229,8 @@ FString UEpicUnrealMCPBridge::ExecuteCommand(const FString& CommandType, const T
             }
             // Blueprint Commands
             else if (CommandType == TEXT("create_blueprint") ||
+                     CommandType == TEXT("reparent_blueprint") ||
+                     CommandType == TEXT("set_widget_is_variable") ||
                      CommandType == TEXT("add_component_to_blueprint") ||
                      CommandType == TEXT("set_physics_properties") ||
                      CommandType == TEXT("compile_blueprint") ||
@@ -248,13 +250,27 @@ FString UEpicUnrealMCPBridge::ExecuteCommand(const FString& CommandType, const T
             }
             // Blueprint Graph Commands
             else if (CommandType == TEXT("add_blueprint_node") ||
+                     CommandType == TEXT("execute_blueprint_graph_batch") ||
+                     CommandType == TEXT("batch_blueprint_graph_commands") ||
+                     CommandType == TEXT("add_set_fields_in_struct_node") ||
+                     CommandType == TEXT("add_set_struct_fields_node") ||
+                     CommandType == TEXT("add_macro_instance_node") ||
+                     CommandType == TEXT("add_standard_macro_node") ||
+                     CommandType == TEXT("add_for_each_loop_node") ||
+                     CommandType == TEXT("add_for_each_loop_with_break_node") ||
+                     CommandType == TEXT("add_reverse_for_each_loop_node") ||
+                     CommandType == TEXT("add_for_loop_node") ||
+                     CommandType == TEXT("add_for_loop_with_break_node") ||
+                     CommandType == TEXT("add_while_loop_node") ||
                      CommandType == TEXT("connect_nodes") ||
+                     CommandType == TEXT("break_pin_links") ||
                      CommandType == TEXT("create_variable") ||
                      CommandType == TEXT("set_blueprint_variable_properties") ||
                      CommandType == TEXT("add_event_node") ||
                      CommandType == TEXT("delete_node") ||
                      CommandType == TEXT("set_node_property") ||
                      CommandType == TEXT("create_function") ||
+                     CommandType == TEXT("create_override_function") ||
                      CommandType == TEXT("add_function_input") ||
                      CommandType == TEXT("add_function_output") ||
                      CommandType == TEXT("delete_function") ||

--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/MCPServerRunnable.cpp
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Private/MCPServerRunnable.cpp
@@ -54,6 +54,7 @@ uint32 FMCPServerRunnable::Run()
                 ClientSocket->SetReceiveBufferSize(SocketBufferSize, SocketBufferSize);
                 
                 uint8 Buffer[8192];
+                FString MessageBuffer;
                 while (bRunning)
                 {
                     int32 BytesRead = 0;
@@ -65,20 +66,23 @@ uint32 FMCPServerRunnable::Run()
                             break;
                         }
 
-                        // Convert received data to string
+                        // Convert received data to string and accumulate it. Large graph batches can be bigger than
+                        // one TCP receive, so parsing each chunk independently drops valid commands.
                         Buffer[BytesRead] = '\0';
                         FString ReceivedText = UTF8_TO_TCHAR(Buffer);
                         UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Received: %s"), *ReceivedText);
+                        MessageBuffer.Append(ReceivedText);
 
                         // Parse JSON
                         TSharedPtr<FJsonObject> JsonObject;
-                        TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(ReceivedText);
+                        TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(MessageBuffer);
                         
-                        if (FJsonSerializer::Deserialize(Reader, JsonObject))
+                        if (FJsonSerializer::Deserialize(Reader, JsonObject) && JsonObject.IsValid())
                         {
                             // Get command type
                             FString CommandType;
-                            if (JsonObject->TryGetStringField(TEXT("type"), CommandType))
+                            if (JsonObject->TryGetStringField(TEXT("type"), CommandType) ||
+                                JsonObject->TryGetStringField(TEXT("command"), CommandType))
                             {
                                 UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Executing command: %s"), *CommandType);
 
@@ -126,15 +130,24 @@ uint32 FMCPServerRunnable::Run()
                                     UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Response sent successfully (%d bytes)"),
                                            TotalBytesSent);
                                 }
+
+                                MessageBuffer.Empty();
                             }
                             else
                             {
                                 UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Missing 'type' field in command"));
+                                MessageBuffer.Empty();
                             }
                         }
                         else
                         {
-                            UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Failed to parse JSON from: %s"), *ReceivedText);
+                            UE_LOG(LogTemp, Verbose, TEXT("MCPServerRunnable: Waiting for the rest of a partial JSON command (%d chars buffered)"), MessageBuffer.Len());
+                            if (MessageBuffer.Len() > 4 * 1024 * 1024)
+                            {
+                                UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Dropping oversized incomplete JSON command"));
+                                MessageBuffer.Empty();
+                                break;
+                            }
                         }
                     }
                     else
@@ -366,4 +379,4 @@ void FMCPServerRunnable::ProcessMessage(TSharedPtr<FSocket> Client, const FStrin
 
     UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Response sent successfully (%d bytes)"),
            TotalBytesSent);
-} 
+}

--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/BlueprintGraph/BPConnector.h
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/BlueprintGraph/BPConnector.h
@@ -23,6 +23,13 @@ public:
      */
     static TSharedPtr<FJsonObject> ConnectNodes(const TSharedPtr<FJsonObject>& Params);
 
+    /**
+     * Breaks all links on one Blueprint node pin.
+     * @param Params JSON containing blueprint_name, node_id, pin_name, optional pin_direction, optional function_name
+     * @return JSON with success and removed link count
+     */
+    static TSharedPtr<FJsonObject> BreakPinLinks(const TSharedPtr<FJsonObject>& Params);
+
 private:
     /**
      * Finds a node by its ID in the graph

--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/BlueprintGraph/NodeManager.h
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/BlueprintGraph/NodeManager.h
@@ -73,6 +73,14 @@ class UNREALMCP_API FBlueprintNodeManager
 		static class UK2Node* CreateCallFunctionNode(class UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params);
 
 		/**
+		 * Create an Enhanced Input Action event node.
+		 * @param Graph - Target graph
+		 * @param Params - Node parameters (must include input_action, optional: pos_x, pos_y)
+		 * @return Created node or nullptr
+		 */
+		static class UK2Node* CreateEnhancedInputActionNode(class UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params);
+
+		/**
 		 * Create a Comparison node (==, >, <, >=, <=)
 		 * @param Graph - Target graph
 		 * @param Params - Node parameters (optional: comparison_type, pos_x, pos_y)

--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/BlueprintGraph/Nodes/DataNodes.h
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/BlueprintGraph/Nodes/DataNodes.h
@@ -1,4 +1,4 @@
-// Header for creating data nodes (Variable Get/Set, MakeArray)
+// Header for creating data nodes (Variable Get/Set, arrays, structs)
 
 #pragma once
 
@@ -36,4 +36,44 @@ public:
 	 * @return The created node or nullptr on error
 	 */
 	static UK2Node* CreateMakeArrayNode(UEdGraph* Graph, const TSharedPtr<class FJsonObject>& Params);
+
+	/**
+	 * Creates a Make Struct node (K2Node_MakeStruct)
+	 * @param Graph - The graph to add the node to
+	 * @param Params - JSON parameters containing pos_x, pos_y, struct_path
+	 * @return The created node or nullptr on error
+	 */
+	static UK2Node* CreateMakeStructNode(UEdGraph* Graph, const TSharedPtr<class FJsonObject>& Params);
+
+	/**
+	 * Creates a Break Struct node (K2Node_BreakStruct)
+	 * @param Graph - The graph to add the node to
+	 * @param Params - JSON parameters containing pos_x, pos_y, struct_path
+	 * @return The created node or nullptr on error
+	 */
+	static UK2Node* CreateBreakStructNode(UEdGraph* Graph, const TSharedPtr<class FJsonObject>& Params);
+
+	/**
+	 * Creates a Set Fields In Struct node (K2Node_SetFieldsInStruct)
+	 * @param Graph - The graph to add the node to
+	 * @param Params - JSON parameters containing pos_x, pos_y, struct_path, optional field_names/fields/member_names or show_all_pins
+	 * @return The created node or nullptr on error
+	 */
+	static UK2Node* CreateSetFieldsInStructNode(UEdGraph* Graph, const TSharedPtr<class FJsonObject>& Params);
+
+	/**
+	 * Creates an Array Get node (K2Node_GetArrayItem)
+	 * @param Graph - The graph to add the node to
+	 * @param Params - JSON parameters containing pos_x, pos_y
+	 * @return The created node or nullptr on error
+	 */
+	static UK2Node* CreateArrayGetNode(UEdGraph* Graph, const TSharedPtr<class FJsonObject>& Params);
+
+	/**
+	 * Creates an array library call node (K2Node_CallArrayFunction)
+	 * @param Graph - The graph to add the node to
+	 * @param Params - JSON parameters containing pos_x, pos_y, target_function
+	 * @return The created node or nullptr on error
+	 */
+	static UK2Node* CreateCallArrayFunctionNode(UEdGraph* Graph, const TSharedPtr<class FJsonObject>& Params);
 };

--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/BlueprintGraph/Nodes/SpecializedNodes.h
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/BlueprintGraph/Nodes/SpecializedNodes.h
@@ -1,4 +1,4 @@
-// Header for creating specialized nodes (Timeline, GetDataTableRow, AddComponentByClass, Self, Knot)
+// Header for creating specialized nodes (Timeline, GetDataTableRow, AddComponentByClass, Self, Knot, macros)
 
 #pragma once
 
@@ -52,4 +52,20 @@ public:
 	 * @return The created node or nullptr on error
 	 */
 	static UK2Node* CreateKnotNode(UEdGraph* Graph, const TSharedPtr<class FJsonObject>& Params);
+
+	/**
+	 * Creates a Macro Instance node (K2Node_MacroInstance)
+	 * @param Graph - The graph to add the node to
+	 * @param Params - JSON parameters containing pos_x, pos_y, macro_name and optional macro_blueprint
+	 * @return The created node or nullptr on error
+	 */
+	static UK2Node* CreateMacroInstanceNode(UEdGraph* Graph, const TSharedPtr<class FJsonObject>& Params);
+
+	/**
+	 * Creates an additional Function Result node using the graph's existing result signature.
+	 * @param Graph - The function graph to add the node to
+	 * @param Params - JSON parameters containing pos_x, pos_y
+	 * @return The created node or nullptr on error
+	 */
+	static UK2Node* CreateFunctionResultNode(UEdGraph* Graph, const TSharedPtr<class FJsonObject>& Params);
 };

--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPBlueprintCommands.h
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPBlueprintCommands.h
@@ -17,6 +17,8 @@ public:
 private:
     // Specific blueprint command handlers (only used functions)
     TSharedPtr<FJsonObject> HandleCreateBlueprint(const TSharedPtr<FJsonObject>& Params);
+    TSharedPtr<FJsonObject> HandleReparentBlueprint(const TSharedPtr<FJsonObject>& Params);
+    TSharedPtr<FJsonObject> HandleSetWidgetIsVariable(const TSharedPtr<FJsonObject>& Params);
     TSharedPtr<FJsonObject> HandleAddComponentToBlueprint(const TSharedPtr<FJsonObject>& Params);
     TSharedPtr<FJsonObject> HandleSetPhysicsProperties(const TSharedPtr<FJsonObject>& Params);
     TSharedPtr<FJsonObject> HandleCompileBlueprint(const TSharedPtr<FJsonObject>& Params);
@@ -38,4 +40,4 @@ private:
     TSharedPtr<FJsonObject> HandleGetBlueprintFunctionDetails(const TSharedPtr<FJsonObject>& Params);
 
 
-}; 
+};

--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPBlueprintGraphCommands.h
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPBlueprintGraphCommands.h
@@ -23,8 +23,14 @@ private:
     // Add node to Blueprint graph
     TSharedPtr<FJsonObject> HandleAddBlueprintNode(const TSharedPtr<FJsonObject>& Params);
 
+    // Add node to Blueprint graph using a command-level node type alias
+    TSharedPtr<FJsonObject> HandleAddBlueprintNodeAlias(const TSharedPtr<FJsonObject>& Params, const FString& NodeType);
+
     // Connect nodes in Blueprint graph
     TSharedPtr<FJsonObject> HandleConnectNodes(const TSharedPtr<FJsonObject>& Params);
+
+    // Break all links on one Blueprint pin
+    TSharedPtr<FJsonObject> HandleBreakPinLinks(const TSharedPtr<FJsonObject>& Params);
 
     // Create variable in Blueprint
     TSharedPtr<FJsonObject> HandleCreateVariable(const TSharedPtr<FJsonObject>& Params);
@@ -44,6 +50,9 @@ private:
     // Create function in Blueprint
     TSharedPtr<FJsonObject> HandleCreateFunction(const TSharedPtr<FJsonObject>& Params);
 
+    // Create an override function graph in Blueprint
+    TSharedPtr<FJsonObject> HandleCreateOverrideFunction(const TSharedPtr<FJsonObject>& Params);
+
     // Add function input parameter
     TSharedPtr<FJsonObject> HandleAddFunctionInput(const TSharedPtr<FJsonObject>& Params);
 
@@ -55,4 +64,7 @@ private:
 
     // Rename function in Blueprint
     TSharedPtr<FJsonObject> HandleRenameFunction(const TSharedPtr<FJsonObject>& Params);
+
+    // Execute multiple generic Blueprint graph operations in one command
+    TSharedPtr<FJsonObject> HandleBatchGraphCommands(const TSharedPtr<FJsonObject>& Params);
 };

--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/UnrealMCP.Build.cs
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/Source/UnrealMCP/UnrealMCP.Build.cs
@@ -34,6 +34,7 @@ public class UnrealMCP : ModuleRules
 				"Core",
 				"CoreUObject",
 				"Engine",
+				"EnhancedInput",
 				"InputCore",
 				"Networking",
 				"Sockets",
@@ -56,6 +57,7 @@ public class UnrealMCP : ModuleRules
 				"Slate",
 				"SlateCore",
 				"Kismet",
+				"UMG",
 				"Projects",
 				"AssetRegistry"
 			}
@@ -68,7 +70,9 @@ public class UnrealMCP : ModuleRules
 				{
 					"PropertyEditor",      // For property editing
 					"ToolMenus",           // For editor UI
-					"BlueprintEditorLibrary" // For Blueprint utilities
+					"BlueprintEditorLibrary", // For Blueprint utilities
+					"InputBlueprintNodes", // For Enhanced Input action event nodes
+					"UMGEditor"            // For WidgetBlueprint authoring
 				}
 			);
 		}
@@ -80,4 +84,4 @@ public class UnrealMCP : ModuleRules
 			}
 		);
 	}
-} 
+}

--- a/FlopperamUnrealMCP/Plugins/UnrealMCP/UnrealMCP.uplugin
+++ b/FlopperamUnrealMCP/Plugins/UnrealMCP/UnrealMCP.uplugin
@@ -30,6 +30,10 @@
 		{
 			"Name": "EditorScriptingUtilities",
 			"Enabled": true
+		},
+		{
+			"Name": "EnhancedInput",
+			"Enabled": true
 		}
 	]
-} 
+}

--- a/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/BPConnector.cpp
+++ b/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/BPConnector.cpp
@@ -8,6 +8,67 @@
 #include "Kismet2/KismetEditorUtilities.h"
 #include "EditorAssetLibrary.h"
 
+namespace
+{
+UBlueprint* LoadConnectorBlueprint(const FString& BlueprintName)
+{
+    FString BlueprintPath = BlueprintName;
+    if (!BlueprintPath.StartsWith(TEXT("/")))
+    {
+        BlueprintPath = TEXT("/Game/Blueprints/") + BlueprintPath;
+    }
+
+    if (!BlueprintPath.Contains(TEXT(".")))
+    {
+        BlueprintPath += TEXT(".") + FPaths::GetBaseFilename(BlueprintPath);
+    }
+
+    if (UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *BlueprintPath))
+    {
+        return Blueprint;
+    }
+
+    if (UEditorAssetLibrary::DoesAssetExist(BlueprintPath))
+    {
+        return Cast<UBlueprint>(UEditorAssetLibrary::LoadAsset(BlueprintPath));
+    }
+
+    return nullptr;
+}
+
+UEdGraph* FindConnectorGraph(UBlueprint* Blueprint, const FString& FunctionName)
+{
+    if (!Blueprint)
+    {
+        return nullptr;
+    }
+
+    if (!FunctionName.IsEmpty())
+    {
+        for (UEdGraph* FuncGraph : Blueprint->FunctionGraphs)
+        {
+            if (FuncGraph && (FuncGraph->GetFName().ToString() == FunctionName ||
+                              (FuncGraph->GetOuter() && FuncGraph->GetOuter()->GetFName().ToString() == FunctionName)))
+            {
+                return FuncGraph;
+            }
+        }
+
+        for (UEdGraph* FuncGraph : Blueprint->FunctionGraphs)
+        {
+            if (FuncGraph && FuncGraph->GetFName().ToString().Contains(FunctionName))
+            {
+                return FuncGraph;
+            }
+        }
+
+        return nullptr;
+    }
+
+    return Blueprint->UbergraphPages.Num() > 0 ? Blueprint->UbergraphPages[0] : nullptr;
+}
+}
+
 TSharedPtr<FJsonObject> FBPConnector::ConnectNodes(const TSharedPtr<FJsonObject>& Params)
 {
     TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
@@ -23,34 +84,7 @@ TSharedPtr<FJsonObject> FBPConnector::ConnectNodes(const TSharedPtr<FJsonObject>
     Params->TryGetStringField(TEXT("function_name"), FunctionName);
 
     // Charger Blueprint - handle both full paths and simple names
-    UBlueprint* Blueprint = nullptr;
-    FString BlueprintPath = BlueprintName;
-
-    // If no path prefix, assume /Game/Blueprints/
-    if (!BlueprintPath.StartsWith(TEXT("/")))
-    {
-        BlueprintPath = TEXT("/Game/Blueprints/") + BlueprintPath;
-    }
-
-    // Add .Blueprint suffix if not present
-    if (!BlueprintPath.Contains(TEXT(".")))
-    {
-        BlueprintPath += TEXT(".") + FPaths::GetBaseFilename(BlueprintPath);
-    }
-
-    // Try to load the Blueprint
-    Blueprint = LoadObject<UBlueprint>(nullptr, *BlueprintPath);
-
-    // If not found, try with UEditorAssetLibrary
-    if (!Blueprint)
-    {
-        FString AssetPath = BlueprintPath;
-        if (UEditorAssetLibrary::DoesAssetExist(AssetPath))
-        {
-            UObject* Asset = UEditorAssetLibrary::LoadAsset(AssetPath);
-            Blueprint = Cast<UBlueprint>(Asset);
-        }
-    }
+    UBlueprint* Blueprint = LoadConnectorBlueprint(BlueprintName);
 
     if (!Blueprint)
     {
@@ -59,54 +93,7 @@ TSharedPtr<FJsonObject> FBPConnector::ConnectNodes(const TSharedPtr<FJsonObject>
         return Result;
     }
 
-    // Get graph
-    UEdGraph* Graph = nullptr;
-
-    if (!FunctionName.IsEmpty())
-    {
-        // Strategy 1: Try exact name match with GetFName()
-        for (UEdGraph* FuncGraph : Blueprint->FunctionGraphs)
-        {
-            if (FuncGraph && (FuncGraph->GetFName().ToString() == FunctionName ||
-                              (FuncGraph->GetOuter() && FuncGraph->GetOuter()->GetFName().ToString() == FunctionName)))
-            {
-                Graph = FuncGraph;
-                break;
-            }
-        }
-
-        // Strategy 2: Fallback - partial match for auto-generated names
-        if (!Graph)
-        {
-            for (UEdGraph* FuncGraph : Blueprint->FunctionGraphs)
-            {
-                if (FuncGraph && FuncGraph->GetFName().ToString().Contains(FunctionName))
-                {
-                    Graph = FuncGraph;
-                    break;
-                }
-            }
-        }
-
-        if (!Graph)
-        {
-            Result->SetBoolField("success", false);
-            Result->SetStringField("error", FString::Printf(TEXT("Function graph not found: %s"), *FunctionName));
-            return Result;
-        }
-    }
-    else
-    {
-        // Use event graph if no function specified
-        if (Blueprint->UbergraphPages.Num() == 0)
-        {
-            Result->SetBoolField("success", false);
-            Result->SetStringField("error", "Blueprint has no event graph");
-            return Result;
-        }
-
-        Graph = Blueprint->UbergraphPages[0];
-    }
+    UEdGraph* Graph = FindConnectorGraph(Blueprint, FunctionName);
 
     if (!Graph)
     {
@@ -137,23 +124,27 @@ TSharedPtr<FJsonObject> FBPConnector::ConnectNodes(const TSharedPtr<FJsonObject>
         return Result;
     }
 
-    // Validate compatibility
-    if (!ArePinsCompatible(SourcePin, TargetPin))
+    const UEdGraphSchema_K2* Schema = GetDefault<UEdGraphSchema_K2>();
+    if (!Schema || !Schema->TryCreateConnection(SourcePin, TargetPin))
     {
         Result->SetBoolField("success", false);
         Result->SetStringField("error", "Pins not compatible");
         return Result;
     }
 
-    // Create connection
-    SourcePin->MakeLinkTo(TargetPin);
+    bool bSkipCompile = false;
+    Params->TryGetBoolField(TEXT("skip_compile"), bSkipCompile);
 
-    // Recompile
     Blueprint->MarkPackageDirty();
-    FKismetEditorUtilities::CompileBlueprint(Blueprint);
+    Graph->NotifyGraphChanged();
+    if (!bSkipCompile)
+    {
+        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+    }
 
     // Return
     Result->SetBoolField("success", true);
+    Result->SetBoolField("compiled", !bSkipCompile);
 
     TSharedPtr<FJsonObject> ConnectionInfo = MakeShared<FJsonObject>();
     ConnectionInfo->SetStringField("source_node", SourceNodeId);
@@ -164,6 +155,73 @@ TSharedPtr<FJsonObject> FBPConnector::ConnectNodes(const TSharedPtr<FJsonObject>
 
     Result->SetObjectField("connection", ConnectionInfo);
 
+    return Result;
+}
+
+TSharedPtr<FJsonObject> FBPConnector::BreakPinLinks(const TSharedPtr<FJsonObject>& Params)
+{
+    TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+
+    FString BlueprintName = Params->GetStringField(TEXT("blueprint_name"));
+    FString NodeId = Params->GetStringField(TEXT("node_id"));
+    FString PinName = Params->GetStringField(TEXT("pin_name"));
+
+    FString FunctionName;
+    Params->TryGetStringField(TEXT("function_name"), FunctionName);
+
+    FString PinDirectionString;
+    Params->TryGetStringField(TEXT("pin_direction"), PinDirectionString);
+    EEdGraphPinDirection Direction = PinDirectionString.Equals(TEXT("input"), ESearchCase::IgnoreCase) ? EGPD_Input : EGPD_Output;
+
+    UBlueprint* Blueprint = LoadConnectorBlueprint(BlueprintName);
+    if (!Blueprint)
+    {
+        Result->SetBoolField("success", false);
+        Result->SetStringField("error", "Blueprint not found");
+        return Result;
+    }
+
+    UEdGraph* Graph = FindConnectorGraph(Blueprint, FunctionName);
+    if (!Graph)
+    {
+        Result->SetBoolField("success", false);
+        Result->SetStringField("error", "Graph not found");
+        return Result;
+    }
+
+    UK2Node* Node = FindNodeById(Graph, NodeId);
+    if (!Node)
+    {
+        Result->SetBoolField("success", false);
+        Result->SetStringField("error", "Node not found");
+        return Result;
+    }
+
+    UEdGraphPin* Pin = FindPinByName(Node, PinName, Direction);
+    if (!Pin)
+    {
+        Result->SetBoolField("success", false);
+        Result->SetStringField("error", "Pin not found");
+        return Result;
+    }
+
+    const int32 RemovedLinks = Pin->LinkedTo.Num();
+    if (const UEdGraphSchema_K2* Schema = GetDefault<UEdGraphSchema_K2>())
+    {
+        Schema->BreakPinLinks(*Pin, true);
+    }
+    else
+    {
+        Pin->BreakAllPinLinks(true);
+    }
+
+    Blueprint->MarkPackageDirty();
+    FKismetEditorUtilities::CompileBlueprint(Blueprint);
+
+    Result->SetBoolField("success", true);
+    Result->SetStringField("node", NodeId);
+    Result->SetStringField("pin", PinName);
+    Result->SetNumberField("removed_links", RemovedLinks);
     return Result;
 }
 
@@ -218,5 +276,6 @@ bool FBPConnector::ArePinsCompatible(UEdGraphPin* SourcePin, UEdGraphPin* Target
         return false;
     }
 
-    return SourcePin->PinType.PinCategory == TargetPin->PinType.PinCategory;
+    const UEdGraphSchema_K2* Schema = GetDefault<UEdGraphSchema_K2>();
+    return Schema && Schema->CanCreateConnection(SourcePin, TargetPin).Response != CONNECT_RESPONSE_DISALLOW;
 }

--- a/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/BPVariables.cpp
+++ b/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/BPVariables.cpp
@@ -9,6 +9,50 @@
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "PropertyEditorModule.h"
 #include "Modules/ModuleManager.h"
+#include "UObject/UnrealType.h"
+
+namespace
+{
+UClass* ResolveBlueprintGeneratedClass(const FString& ObjectPath)
+{
+    if (ObjectPath.IsEmpty())
+    {
+        return nullptr;
+    }
+
+    if (UClass* Class = LoadClass<UObject>(nullptr, *ObjectPath))
+    {
+        return Class;
+    }
+
+    if (UClass* Class = FindObject<UClass>(nullptr, *ObjectPath))
+    {
+        return Class;
+    }
+
+    if (UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *ObjectPath))
+    {
+        return Blueprint->GeneratedClass;
+    }
+
+    return nullptr;
+}
+
+UObject* ResolveTypeObject(const FString& ObjectPath)
+{
+    if (ObjectPath.IsEmpty())
+    {
+        return nullptr;
+    }
+
+    if (UObject* Object = StaticLoadObject(UObject::StaticClass(), nullptr, *ObjectPath))
+    {
+        return Object;
+    }
+
+    return FindObject<UObject>(nullptr, *ObjectPath);
+}
+}
 
 TSharedPtr<FJsonObject> FBPVariables::CreateVariable(const TSharedPtr<FJsonObject>& Params)
 {
@@ -396,33 +440,81 @@ TSharedPtr<FJsonObject> FBPVariables::SetVariableProperties(const TSharedPtr<FJs
 FEdGraphPinType FBPVariables::GetPinTypeFromString(const FString& TypeString)
 {
     FEdGraphPinType PinType;
+    FString WorkingType = TypeString;
+    if (WorkingType.StartsWith(TEXT("array:")))
+    {
+        WorkingType.RightChopInline(6);
+        PinType.ContainerType = EPinContainerType::Array;
+    }
 
-    if (TypeString == "bool")
+    if (WorkingType == "bool")
     {
         PinType.PinCategory = UEdGraphSchema_K2::PC_Boolean;
     }
-    else if (TypeString == "int")
+    else if (WorkingType == "int")
     {
         PinType.PinCategory = UEdGraphSchema_K2::PC_Int;
     }
-    else if (TypeString == "float")
+    else if (WorkingType == "float")
     {
         PinType.PinCategory = UEdGraphSchema_K2::PC_Real;
         PinType.PinSubCategory = UEdGraphSchema_K2::PC_Float;
     }
-    else if (TypeString == "string")
+    else if (WorkingType == "string")
     {
         PinType.PinCategory = UEdGraphSchema_K2::PC_String;
     }
-    else if (TypeString == "vector")
+    else if (WorkingType == "text")
+    {
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Text;
+    }
+    else if (WorkingType == "name")
+    {
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Name;
+    }
+    else if (WorkingType == "byte")
+    {
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Byte;
+    }
+    else if (WorkingType == "vector")
     {
         PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
         PinType.PinSubCategoryObject = TBaseStructure<FVector>::Get();
     }
-    else if (TypeString == "rotator")
+    else if (WorkingType == "vector2d")
+    {
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
+        PinType.PinSubCategoryObject = TBaseStructure<FVector2D>::Get();
+    }
+    else if (WorkingType == "rotator")
     {
         PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
         PinType.PinSubCategoryObject = TBaseStructure<FRotator>::Get();
+    }
+    else if (WorkingType == "intpoint")
+    {
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
+        PinType.PinSubCategoryObject = TBaseStructure<FIntPoint>::Get();
+    }
+    else if (WorkingType.StartsWith(TEXT("enum:")))
+    {
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Byte;
+        PinType.PinSubCategoryObject = Cast<UEnum>(ResolveTypeObject(WorkingType.RightChop(5)));
+    }
+    else if (WorkingType.StartsWith(TEXT("struct:")))
+    {
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
+        PinType.PinSubCategoryObject = Cast<UScriptStruct>(ResolveTypeObject(WorkingType.RightChop(7)));
+    }
+    else if (WorkingType.StartsWith(TEXT("object:")))
+    {
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Object;
+        PinType.PinSubCategoryObject = ResolveBlueprintGeneratedClass(WorkingType.RightChop(7));
+    }
+    else if (WorkingType.StartsWith(TEXT("class:")))
+    {
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Class;
+        PinType.PinSubCategoryObject = ResolveBlueprintGeneratedClass(WorkingType.RightChop(6));
     }
     else
     {

--- a/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/Function/FunctionIO.cpp
+++ b/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/Function/FunctionIO.cpp
@@ -9,6 +9,8 @@
 #include "K2Node_CallFunction.h"
 #include "EditorAssetLibrary.h"
 #include "EdGraph/EdGraphNode.h"
+#include "UObject/Class.h"
+#include "UObject/UnrealType.h"
 
 TSharedPtr<FJsonObject> FFunctionIO::AddFunctionIO(const TSharedPtr<FJsonObject>& Params)
 {
@@ -158,6 +160,10 @@ bool FFunctionIO::AddFunctionParameter(
 
 	// Create the property type
 	FEdGraphPinType PropertyType = GetPropertyTypeFromString(ParamType);
+	if (bIsArray)
+	{
+		PropertyType.ContainerType = EPinContainerType::Array;
+	}
 
 	UEdGraphPin* NewPin = nullptr;
 
@@ -328,14 +334,60 @@ FEdGraphPinType FFunctionIO::GetPropertyTypeFromString(const FString& TypeName)
 		PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
 		PinType.PinSubCategoryObject = TBaseStructure<FVector>::Get();
 	}
+	else if (TypeName == TEXT("vector2d") || TypeName == TEXT("FVector2D"))
+	{
+		PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
+		PinType.PinSubCategoryObject = TBaseStructure<FVector2D>::Get();
+	}
 	else if (TypeName == TEXT("rotator") || TypeName == TEXT("FRotator"))
 	{
 		PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
 		PinType.PinSubCategoryObject = TBaseStructure<FRotator>::Get();
 	}
+	else if (TypeName == TEXT("intpoint") || TypeName == TEXT("FIntPoint"))
+	{
+		PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
+		PinType.PinSubCategoryObject = TBaseStructure<FIntPoint>::Get();
+	}
+	else if (TypeName == TEXT("name") || TypeName == TEXT("FName"))
+	{
+		PinType.PinCategory = UEdGraphSchema_K2::PC_Name;
+	}
 	else if (TypeName == TEXT("object"))
 	{
 		PinType.PinCategory = UEdGraphSchema_K2::PC_Object;
+	}
+	else if (TypeName.StartsWith(TEXT("enum:"), ESearchCase::IgnoreCase))
+	{
+		const FString EnumPath = TypeName.RightChop(5);
+		if (UEnum* EnumType = LoadObject<UEnum>(nullptr, *EnumPath))
+		{
+			PinType.PinCategory = UEdGraphSchema_K2::PC_Byte;
+			PinType.PinSubCategoryObject = EnumType;
+		}
+		else
+		{
+			PinType.PinCategory = UEdGraphSchema_K2::PC_Byte;
+		}
+	}
+	else if (TypeName.StartsWith(TEXT("struct:"), ESearchCase::IgnoreCase))
+	{
+		const FString StructPath = TypeName.RightChop(7);
+		if (UScriptStruct* StructType = LoadObject<UScriptStruct>(nullptr, *StructPath))
+		{
+			PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
+			PinType.PinSubCategoryObject = StructType;
+		}
+		else
+		{
+			PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
+		}
+	}
+	else if (TypeName.StartsWith(TEXT("object:"), ESearchCase::IgnoreCase))
+	{
+		const FString ClassPath = TypeName.RightChop(7);
+		PinType.PinCategory = UEdGraphSchema_K2::PC_Object;
+		PinType.PinSubCategoryObject = LoadObject<UClass>(nullptr, *ClassPath);
 	}
 	else
 	{

--- a/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/NodeManager.cpp
+++ b/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/NodeManager.cpp
@@ -10,6 +10,7 @@
 #include "EdGraphSchema_K2.h"
 #include "K2Node_CallFunction.h"
 #include "K2Node_Event.h"
+#include "K2Node_EnhancedInputAction.h"
 #include "K2Node_VariableGet.h"
 #include "K2Node_VariableSet.h"
 #include "K2Node_PromotableOperator.h"
@@ -20,6 +21,56 @@
 #include "EditorAssetLibrary.h"
 #include "Kismet/KismetSystemLibrary.h"
 #include "Kismet/KismetMathLibrary.h"
+#include "InputAction.h"
+
+namespace
+{
+	FString ResolveStandardMacroAlias(const FString& NodeType)
+	{
+		FString CompactNodeType = NodeType;
+		CompactNodeType.ReplaceInline(TEXT("_"), TEXT(""));
+		CompactNodeType.ReplaceInline(TEXT("-"), TEXT(""));
+		CompactNodeType.ReplaceInline(TEXT(" "), TEXT(""));
+
+		if (CompactNodeType.Equals(TEXT("ForEach"), ESearchCase::IgnoreCase) ||
+			CompactNodeType.Equals(TEXT("ForEachLoop"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("ForEachLoop");
+		}
+
+		if (CompactNodeType.Equals(TEXT("ForEachWithBreak"), ESearchCase::IgnoreCase) ||
+			CompactNodeType.Equals(TEXT("ForEachLoopWithBreak"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("ForEachLoopWithBreak");
+		}
+
+		if (CompactNodeType.Equals(TEXT("ReverseForEach"), ESearchCase::IgnoreCase) ||
+			CompactNodeType.Equals(TEXT("ReverseForEachLoop"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("ReverseForEachLoop");
+		}
+
+		if (CompactNodeType.Equals(TEXT("For"), ESearchCase::IgnoreCase) ||
+			CompactNodeType.Equals(TEXT("ForLoop"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("ForLoop");
+		}
+
+		if (CompactNodeType.Equals(TEXT("ForWithBreak"), ESearchCase::IgnoreCase) ||
+			CompactNodeType.Equals(TEXT("ForLoopWithBreak"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("ForLoopWithBreak");
+		}
+
+		if (CompactNodeType.Equals(TEXT("While"), ESearchCase::IgnoreCase) ||
+			CompactNodeType.Equals(TEXT("WhileLoop"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("WhileLoop");
+		}
+
+		return FString();
+	}
+}
 
 TSharedPtr<FJsonObject> FBlueprintNodeManager::AddNode(const TSharedPtr<FJsonObject>& Params)
 {
@@ -152,6 +203,28 @@ TSharedPtr<FJsonObject> FBlueprintNodeManager::AddNode(const TSharedPtr<FJsonObj
 	{
 		NewNode = FDataNodeCreator::CreateMakeArrayNode(Graph, NodeParams);
 	}
+	else if (NodeType.Equals(TEXT("MakeStruct"), ESearchCase::IgnoreCase))
+	{
+		NewNode = FDataNodeCreator::CreateMakeStructNode(Graph, NodeParams);
+	}
+	else if (NodeType.Equals(TEXT("BreakStruct"), ESearchCase::IgnoreCase))
+	{
+		NewNode = FDataNodeCreator::CreateBreakStructNode(Graph, NodeParams);
+	}
+	else if (NodeType.Equals(TEXT("SetFieldsInStruct"), ESearchCase::IgnoreCase) ||
+			 NodeType.Equals(TEXT("SetMembersInStruct"), ESearchCase::IgnoreCase) ||
+			 NodeType.Equals(TEXT("SetStructFields"), ESearchCase::IgnoreCase))
+	{
+		NewNode = FDataNodeCreator::CreateSetFieldsInStructNode(Graph, NodeParams);
+	}
+	else if (NodeType.Equals(TEXT("ArrayGet"), ESearchCase::IgnoreCase))
+	{
+		NewNode = FDataNodeCreator::CreateArrayGetNode(Graph, NodeParams);
+	}
+	else if (NodeType.Equals(TEXT("CallArrayFunction"), ESearchCase::IgnoreCase))
+	{
+		NewNode = FDataNodeCreator::CreateCallArrayFunctionNode(Graph, NodeParams);
+	}
 	// Utility Nodes
 	else if (NodeType.Equals(TEXT("Print"), ESearchCase::IgnoreCase))
 	{
@@ -160,6 +233,10 @@ TSharedPtr<FJsonObject> FBlueprintNodeManager::AddNode(const TSharedPtr<FJsonObj
 	else if (NodeType.Equals(TEXT("CallFunction"), ESearchCase::IgnoreCase))
 	{
 		NewNode = FUtilityNodeCreator::CreateCallFunctionNode(Graph, NodeParams);
+	}
+	else if (NodeType.Equals(TEXT("EnhancedInputAction"), ESearchCase::IgnoreCase))
+	{
+		NewNode = CreateEnhancedInputActionNode(Graph, NodeParams);
 	}
 	else if (NodeType.Equals(TEXT("Select"), ESearchCase::IgnoreCase))
 	{
@@ -208,14 +285,31 @@ TSharedPtr<FJsonObject> FBlueprintNodeManager::AddNode(const TSharedPtr<FJsonObj
 	{
 		NewNode = FSpecializedNodeCreator::CreateKnotNode(Graph, NodeParams);
 	}
-	// Event nodes (kept for backward compatibility - should use add_event_node)
-	else if (NodeType.Equals(TEXT("Event"), ESearchCase::IgnoreCase))
-	{
-		NewNode = CreateEventNode(Graph, NodeParams);
-	}
 	else
 	{
-		return CreateErrorResponse(FString::Printf(TEXT("Unknown node type: %s"), *NodeType));
+		const FString StandardMacroName = ResolveStandardMacroAlias(NodeType);
+		if (!StandardMacroName.IsEmpty())
+		{
+			NodeParams->SetStringField(TEXT("macro_name"), StandardMacroName);
+			NewNode = FSpecializedNodeCreator::CreateMacroInstanceNode(Graph, NodeParams);
+		}
+		else if (NodeType.Equals(TEXT("MacroInstance"), ESearchCase::IgnoreCase))
+		{
+			NewNode = FSpecializedNodeCreator::CreateMacroInstanceNode(Graph, NodeParams);
+		}
+		else if (NodeType.Equals(TEXT("FunctionResult"), ESearchCase::IgnoreCase))
+		{
+			NewNode = FSpecializedNodeCreator::CreateFunctionResultNode(Graph, NodeParams);
+		}
+		// Event nodes (kept for backward compatibility - should use add_event_node)
+		else if (NodeType.Equals(TEXT("Event"), ESearchCase::IgnoreCase))
+		{
+			NewNode = CreateEventNode(Graph, NodeParams);
+		}
+		else
+		{
+			return CreateErrorResponse(FString::Printf(TEXT("Unknown node type: %s"), *NodeType));
+		}
 	}
 
 	if (!NewNode)
@@ -485,6 +579,54 @@ UK2Node* FBlueprintNodeManager::CreateCallFunctionNode(UEdGraph* Graph, const TS
 	CallNode->AllocateDefaultPins();
 
 	return CallNode;
+}
+
+UK2Node* FBlueprintNodeManager::CreateEnhancedInputActionNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
+{
+	if (!Graph || !Params.IsValid())
+	{
+		return nullptr;
+	}
+
+	FString InputActionPath;
+	if (!Params->TryGetStringField(TEXT("input_action"), InputActionPath) || InputActionPath.IsEmpty())
+	{
+		return nullptr;
+	}
+
+	UInputAction* InputAction = LoadObject<UInputAction>(nullptr, *InputActionPath);
+	if (!InputAction && !InputActionPath.Contains(TEXT(".")))
+	{
+		const FString ObjectPath = InputActionPath + TEXT(".") + FPaths::GetBaseFilename(InputActionPath);
+		InputAction = LoadObject<UInputAction>(nullptr, *ObjectPath);
+	}
+
+	if (!InputAction)
+	{
+		return nullptr;
+	}
+
+	UK2Node_EnhancedInputAction* InputActionNode = NewObject<UK2Node_EnhancedInputAction>(Graph);
+	if (!InputActionNode)
+	{
+		return nullptr;
+	}
+
+	double PosX = 0.0;
+	double PosY = 0.0;
+	Params->TryGetNumberField(TEXT("pos_x"), PosX);
+	Params->TryGetNumberField(TEXT("pos_y"), PosY);
+
+	InputActionNode->InputAction = InputAction;
+	InputActionNode->NodePosX = static_cast<int32>(PosX);
+	InputActionNode->NodePosY = static_cast<int32>(PosY);
+
+	Graph->AddNode(InputActionNode, true, false);
+	InputActionNode->CreateNewGuid();
+	InputActionNode->PostPlacedNewNode();
+	InputActionNode->AllocateDefaultPins();
+
+	return InputActionNode;
 }
 
 UK2Node* FBlueprintNodeManager::CreateComparisonNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)

--- a/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/NodePropertyManager.cpp
+++ b/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/NodePropertyManager.cpp
@@ -26,6 +26,24 @@
 #include "EditorAssetLibrary.h"
 #include "Json.h"
 
+namespace
+{
+UClass* ResolveBlueprintCallableClass(const FString& ClassPath)
+{
+	if (ClassPath.IsEmpty())
+	{
+		return UKismetSystemLibrary::StaticClass();
+	}
+
+	if (UClass* FoundClass = FindObject<UClass>(nullptr, *ClassPath))
+	{
+		return FoundClass;
+	}
+
+	return LoadObject<UClass>(nullptr, *ClassPath);
+}
+}
+
 TSharedPtr<FJsonObject> FNodePropertyManager::SetNodeProperty(const TSharedPtr<FJsonObject>& Params)
 {
 	// Validate parameters
@@ -345,6 +363,57 @@ TSharedPtr<FJsonObject> FNodePropertyManager::DispatchEditAction(
 		}
 	}
 
+	// === CALLFUNCTION: Change the referenced UFunction ===
+	if (Action.Equals(TEXT("set_function_call"), ESearchCase::IgnoreCase))
+	{
+		UK2Node_CallFunction* CallFunctionNode = Cast<UK2Node_CallFunction>(Node);
+		if (!CallFunctionNode)
+		{
+			return CreateErrorResponse(TEXT("Node is not a CallFunction node"));
+		}
+
+		FString TargetFunction;
+		if (!Params->TryGetStringField(TEXT("target_function"), TargetFunction) || TargetFunction.IsEmpty())
+		{
+			return CreateErrorResponse(TEXT("Missing 'target_function' parameter"));
+		}
+
+		FString TargetClassPath;
+		Params->TryGetStringField(TEXT("target_class"), TargetClassPath);
+
+		UClass* TargetClass = ResolveBlueprintCallableClass(TargetClassPath);
+		if (!TargetClass)
+		{
+			return CreateErrorResponse(FString::Printf(TEXT("Target class not found: %s"), *TargetClassPath));
+		}
+
+		UFunction* TargetFunc = TargetClass->FindFunctionByName(FName(*TargetFunction));
+		if (!TargetFunc)
+		{
+			return CreateErrorResponse(FString::Printf(
+				TEXT("Function '%s' not found on class '%s'"),
+				*TargetFunction,
+				*TargetClass->GetName()));
+		}
+
+		CallFunctionNode->Modify();
+		CallFunctionNode->SetFromFunction(TargetFunc);
+		CallFunctionNode->ReconstructNode();
+
+		Graph->NotifyGraphChanged();
+		if (UBlueprint* Blueprint = FBlueprintEditorUtils::FindBlueprintForGraph(Graph))
+		{
+			FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
+		}
+
+		TSharedPtr<FJsonObject> Response = MakeShareable(new FJsonObject);
+		Response->SetBoolField(TEXT("success"), true);
+		Response->SetStringField(TEXT("action"), TEXT("set_function_call"));
+		Response->SetStringField(TEXT("target_function"), TargetFunction);
+		Response->SetStringField(TEXT("target_class"), TargetClass->GetPathName());
+		return Response;
+	}
+
 	// Unknown action
 	return CreateErrorResponse(FString::Printf(TEXT("Unknown action: %s"), *Action));
 }
@@ -469,6 +538,45 @@ bool FNodePropertyManager::SetGenericNodeProperty(
 		{
 			Node->NodeComment = Comment;
 			return true;
+		}
+	}
+
+	// Handle "pin_default:<PinName>" for generic pin default authoring.
+	if (PropertyName.StartsWith(TEXT("pin_default:"), ESearchCase::IgnoreCase))
+	{
+		const FString PinName = PropertyName.RightChop(12);
+		FString DefaultValue;
+		if (!PinName.IsEmpty() && Value->TryGetString(DefaultValue))
+		{
+			if (UEdGraphPin* Pin = Node->FindPin(FName(*PinName)))
+			{
+				Pin->DefaultValue = DefaultValue;
+				return true;
+			}
+		}
+	}
+
+	if (PropertyName.StartsWith(TEXT("pin_default_object:"), ESearchCase::IgnoreCase))
+	{
+		const FString PinName = PropertyName.RightChop(19);
+		FString ObjectPath;
+		if (!PinName.IsEmpty() && Value->TryGetString(ObjectPath))
+		{
+			if (UEdGraphPin* Pin = Node->FindPin(FName(*PinName)))
+			{
+				UObject* LoadedObject = LoadObject<UObject>(nullptr, *ObjectPath);
+				if (!LoadedObject)
+				{
+					LoadedObject = StaticLoadObject(UObject::StaticClass(), nullptr, *ObjectPath);
+				}
+				if (LoadedObject)
+				{
+					Pin->DefaultObject = LoadedObject;
+					Pin->DefaultValue.Reset();
+					Pin->DefaultTextValue = FText::GetEmpty();
+					return true;
+				}
+			}
 		}
 	}
 

--- a/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/Nodes/CastingNodes.cpp
+++ b/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/Nodes/CastingNodes.cpp
@@ -4,7 +4,35 @@
 #include "K2Node_CastByteToEnum.h"
 #include "K2Node_ClassDynamicCast.h"
 #include "K2Node_DynamicCast.h"
+#include "Engine/Blueprint.h"
 
+namespace
+{
+UClass* ResolveClassForCastNode(const FString& ClassPath)
+{
+  if (ClassPath.IsEmpty())
+  {
+    return nullptr;
+  }
+
+  if (UClass* Class = Cast<UClass>(StaticFindObject(UClass::StaticClass(), nullptr, *ClassPath)))
+  {
+    return Class;
+  }
+
+  if (UClass* Class = LoadObject<UClass>(nullptr, *ClassPath))
+  {
+    return Class;
+  }
+
+  if (UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *ClassPath))
+  {
+    return Blueprint->GeneratedClass;
+  }
+
+  return nullptr;
+}
+}
 
 UK2Node *FCastingNodeCreator::CreateDynamicCastNode(
     UEdGraph *Graph, const TSharedPtr<FJsonObject> &Params) {
@@ -20,8 +48,7 @@ UK2Node *FCastingNodeCreator::CreateDynamicCastNode(
   // Set target class BEFORE initialization
   FString TargetClass;
   if (Params->TryGetStringField(TEXT("target_class"), TargetClass)) {
-    UClass *CastClass = Cast<UClass>(
-        StaticFindObject(UClass::StaticClass(), nullptr, *TargetClass));
+    UClass *CastClass = ResolveClassForCastNode(TargetClass);
     if (CastClass) {
       DynamicCastNode->TargetType = CastClass;
     }
@@ -53,8 +80,7 @@ UK2Node *FCastingNodeCreator::CreateClassDynamicCastNode(
   // Set target class BEFORE initialization
   FString TargetClass;
   if (Params->TryGetStringField(TEXT("target_class"), TargetClass)) {
-    UClass *CastClass = Cast<UClass>(
-        StaticFindObject(UClass::StaticClass(), nullptr, *TargetClass));
+    UClass *CastClass = ResolveClassForCastNode(TargetClass);
     if (CastClass) {
       ClassDynamicCastNode->TargetType = CastClass;
     }

--- a/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/Nodes/DataNodes.cpp
+++ b/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/Nodes/DataNodes.cpp
@@ -3,7 +3,130 @@
 #include "K2Node_VariableGet.h"
 #include "K2Node_VariableSet.h"
 #include "K2Node_MakeArray.h"
+#include "K2Node_MakeStruct.h"
+#include "K2Node_BreakStruct.h"
+#include "K2Node_SetFieldsInStruct.h"
+#include "K2Node_GetArrayItem.h"
+#include "K2Node_CallArrayFunction.h"
+#include "Engine/Blueprint.h"
+#include "Kismet/KismetArrayLibrary.h"
+#include "UObject/UnrealType.h"
 #include "Json.h"
+
+namespace
+{
+	UScriptStruct* ResolveScriptStruct(const FString& StructPath)
+	{
+		if (StructPath.IsEmpty())
+		{
+			return nullptr;
+		}
+
+		if (UScriptStruct* FoundStruct = FindObject<UScriptStruct>(nullptr, *StructPath))
+		{
+			return FoundStruct;
+		}
+
+		return LoadObject<UScriptStruct>(nullptr, *StructPath);
+	}
+
+	void AddRequestedFieldName(const UScriptStruct* StructType, const FString& RequestedName, TSet<FName>& FieldNames)
+	{
+		if (RequestedName.IsEmpty())
+		{
+			return;
+		}
+
+		if (StructType)
+		{
+			for (TFieldIterator<FProperty> PropIt(StructType, EFieldIteratorFlags::IncludeSuper); PropIt; ++PropIt)
+			{
+				FProperty* Property = *PropIt;
+				if (Property && Property->GetName().Equals(RequestedName, ESearchCase::IgnoreCase))
+				{
+					FieldNames.Add(Property->GetFName());
+					return;
+				}
+			}
+		}
+
+		FieldNames.Add(FName(*RequestedName));
+	}
+
+	void AddRequestedFieldArray(const TSharedPtr<FJsonObject>& Params, const TCHAR* FieldName, const UScriptStruct* StructType, TSet<FName>& FieldNames)
+	{
+		const TArray<TSharedPtr<FJsonValue>>* RequestedFields = nullptr;
+		if (!Params->TryGetArrayField(FieldName, RequestedFields))
+		{
+			return;
+		}
+
+		for (const TSharedPtr<FJsonValue>& FieldValue : *RequestedFields)
+		{
+			FString RequestedName;
+			if (FieldValue.IsValid() && FieldValue->TryGetString(RequestedName))
+			{
+				AddRequestedFieldName(StructType, RequestedName, FieldNames);
+			}
+		}
+	}
+
+	TSet<FName> GetRequestedStructFields(const TSharedPtr<FJsonObject>& Params, const UScriptStruct* StructType)
+	{
+		TSet<FName> FieldNames;
+
+		bool bShowAllFields = false;
+		bool bBoolValue = false;
+		if (Params->TryGetBoolField(TEXT("show_all_pins"), bBoolValue))
+		{
+			bShowAllFields |= bBoolValue;
+		}
+		if (Params->TryGetBoolField(TEXT("show_all_fields"), bBoolValue))
+		{
+			bShowAllFields |= bBoolValue;
+		}
+
+		if (bShowAllFields && StructType)
+		{
+			for (TFieldIterator<FProperty> PropIt(StructType, EFieldIteratorFlags::IncludeSuper); PropIt; ++PropIt)
+			{
+				if (FProperty* Property = *PropIt)
+				{
+					FieldNames.Add(Property->GetFName());
+				}
+			}
+		}
+
+		FString SingleFieldName;
+		if (Params->TryGetStringField(TEXT("field_name"), SingleFieldName))
+		{
+			AddRequestedFieldName(StructType, SingleFieldName, FieldNames);
+		}
+
+		AddRequestedFieldArray(Params, TEXT("field_names"), StructType, FieldNames);
+		AddRequestedFieldArray(Params, TEXT("fields"), StructType, FieldNames);
+		AddRequestedFieldArray(Params, TEXT("member_names"), StructType, FieldNames);
+
+		return FieldNames;
+	}
+
+	void PrimeVisibleStructFields(UK2Node_SetFieldsInStruct* SetFieldsNode, const TSet<FName>& FieldNames)
+	{
+		if (!SetFieldsNode || FieldNames.IsEmpty())
+		{
+			return;
+		}
+
+		SetFieldsNode->ShowPinForProperties.Reset();
+		for (const FName& FieldName : FieldNames)
+		{
+			FOptionalPinFromProperty& PinRecord = SetFieldsNode->ShowPinForProperties.AddDefaulted_GetRef();
+			PinRecord.PropertyName = FieldName;
+			PinRecord.bShowPin = true;
+			PinRecord.bCanToggleVisibility = true;
+		}
+	}
+}
 
 UK2Node* FDataNodeCreator::CreateVariableGetNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
 {
@@ -24,7 +147,22 @@ UK2Node* FDataNodeCreator::CreateVariableGetNode(UEdGraph* Graph, const TSharedP
 		return nullptr;
 	}
 
-	VarGetNode->VariableReference.SetSelfMember(FName(*VariableName));
+	FString TargetBlueprintPath;
+	if (Params->TryGetStringField(TEXT("target_blueprint"), TargetBlueprintPath))
+	{
+		if (UBlueprint* TargetBlueprint = LoadObject<UBlueprint>(nullptr, *TargetBlueprintPath))
+		{
+			VarGetNode->VariableReference.SetExternalMember(FName(*VariableName), TargetBlueprint->GeneratedClass);
+		}
+		else
+		{
+			VarGetNode->VariableReference.SetSelfMember(FName(*VariableName));
+		}
+	}
+	else
+	{
+		VarGetNode->VariableReference.SetSelfMember(FName(*VariableName));
+	}
 
 	double PosX, PosY;
 	FNodeCreatorUtils::ExtractNodePosition(Params, PosX, PosY);
@@ -92,5 +230,182 @@ UK2Node* FDataNodeCreator::CreateMakeArrayNode(UEdGraph* Graph, const TSharedPtr
 	FNodeCreatorUtils::InitializeK2Node(MakeArrayNode, Graph);
 
 	return MakeArrayNode;
+}
+
+UK2Node* FDataNodeCreator::CreateMakeStructNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
+{
+	if (!Graph || !Params.IsValid())
+	{
+		return nullptr;
+	}
+
+	FString StructPath;
+	if (!Params->TryGetStringField(TEXT("struct_path"), StructPath))
+	{
+		Params->TryGetStringField(TEXT("target_blueprint"), StructPath);
+	}
+
+	UScriptStruct* StructType = ResolveScriptStruct(StructPath);
+	if (!StructType)
+	{
+		return nullptr;
+	}
+
+	UK2Node_MakeStruct* MakeStructNode = NewObject<UK2Node_MakeStruct>(Graph);
+	if (!MakeStructNode)
+	{
+		return nullptr;
+	}
+
+	MakeStructNode->StructType = StructType;
+
+	double PosX, PosY;
+	FNodeCreatorUtils::ExtractNodePosition(Params, PosX, PosY);
+	MakeStructNode->NodePosX = static_cast<int32>(PosX);
+	MakeStructNode->NodePosY = static_cast<int32>(PosY);
+
+	Graph->AddNode(MakeStructNode, true, false);
+	FNodeCreatorUtils::InitializeK2Node(MakeStructNode, Graph);
+
+	return MakeStructNode;
+}
+
+UK2Node* FDataNodeCreator::CreateBreakStructNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
+{
+	if (!Graph || !Params.IsValid())
+	{
+		return nullptr;
+	}
+
+	FString StructPath;
+	if (!Params->TryGetStringField(TEXT("struct_path"), StructPath))
+	{
+		Params->TryGetStringField(TEXT("target_blueprint"), StructPath);
+	}
+
+	UScriptStruct* StructType = ResolveScriptStruct(StructPath);
+	if (!StructType)
+	{
+		return nullptr;
+	}
+
+	UK2Node_BreakStruct* BreakStructNode = NewObject<UK2Node_BreakStruct>(Graph);
+	if (!BreakStructNode)
+	{
+		return nullptr;
+	}
+
+	BreakStructNode->StructType = StructType;
+
+	double PosX, PosY;
+	FNodeCreatorUtils::ExtractNodePosition(Params, PosX, PosY);
+	BreakStructNode->NodePosX = static_cast<int32>(PosX);
+	BreakStructNode->NodePosY = static_cast<int32>(PosY);
+
+	Graph->AddNode(BreakStructNode, true, false);
+	FNodeCreatorUtils::InitializeK2Node(BreakStructNode, Graph);
+
+	return BreakStructNode;
+}
+
+UK2Node* FDataNodeCreator::CreateSetFieldsInStructNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
+{
+	if (!Graph || !Params.IsValid())
+	{
+		return nullptr;
+	}
+
+	FString StructPath;
+	if (!Params->TryGetStringField(TEXT("struct_path"), StructPath))
+	{
+		Params->TryGetStringField(TEXT("target_blueprint"), StructPath);
+	}
+
+	UScriptStruct* StructType = ResolveScriptStruct(StructPath);
+	if (!StructType)
+	{
+		return nullptr;
+	}
+
+	UK2Node_SetFieldsInStruct* SetFieldsNode = NewObject<UK2Node_SetFieldsInStruct>(Graph);
+	if (!SetFieldsNode)
+	{
+		return nullptr;
+	}
+
+	SetFieldsNode->StructType = StructType;
+	PrimeVisibleStructFields(SetFieldsNode, GetRequestedStructFields(Params, StructType));
+
+	double PosX, PosY;
+	FNodeCreatorUtils::ExtractNodePosition(Params, PosX, PosY);
+	SetFieldsNode->NodePosX = static_cast<int32>(PosX);
+	SetFieldsNode->NodePosY = static_cast<int32>(PosY);
+
+	Graph->AddNode(SetFieldsNode, true, false);
+	FNodeCreatorUtils::InitializeK2Node(SetFieldsNode, Graph);
+
+	return SetFieldsNode;
+}
+
+UK2Node* FDataNodeCreator::CreateArrayGetNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
+{
+	if (!Graph || !Params.IsValid())
+	{
+		return nullptr;
+	}
+
+	UK2Node_GetArrayItem* ArrayGetNode = NewObject<UK2Node_GetArrayItem>(Graph);
+	if (!ArrayGetNode)
+	{
+		return nullptr;
+	}
+
+	double PosX, PosY;
+	FNodeCreatorUtils::ExtractNodePosition(Params, PosX, PosY);
+	ArrayGetNode->NodePosX = static_cast<int32>(PosX);
+	ArrayGetNode->NodePosY = static_cast<int32>(PosY);
+
+	Graph->AddNode(ArrayGetNode, true, false);
+	FNodeCreatorUtils::InitializeK2Node(ArrayGetNode, Graph);
+
+	return ArrayGetNode;
+}
+
+UK2Node* FDataNodeCreator::CreateCallArrayFunctionNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
+{
+	if (!Graph || !Params.IsValid())
+	{
+		return nullptr;
+	}
+
+	FString TargetFunction;
+	if (!Params->TryGetStringField(TEXT("target_function"), TargetFunction))
+	{
+		return nullptr;
+	}
+
+	UFunction* TargetFunc = UKismetArrayLibrary::StaticClass()->FindFunctionByName(FName(*TargetFunction));
+	if (!TargetFunc)
+	{
+		return nullptr;
+	}
+
+	UK2Node_CallArrayFunction* CallArrayNode = NewObject<UK2Node_CallArrayFunction>(Graph);
+	if (!CallArrayNode)
+	{
+		return nullptr;
+	}
+
+	CallArrayNode->SetFromFunction(TargetFunc);
+
+	double PosX, PosY;
+	FNodeCreatorUtils::ExtractNodePosition(Params, PosX, PosY);
+	CallArrayNode->NodePosX = static_cast<int32>(PosX);
+	CallArrayNode->NodePosY = static_cast<int32>(PosY);
+
+	Graph->AddNode(CallArrayNode, true, false);
+	FNodeCreatorUtils::InitializeK2Node(CallArrayNode, Graph);
+
+	return CallArrayNode;
 }
 

--- a/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/Nodes/SpecializedNodes.cpp
+++ b/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/Nodes/SpecializedNodes.cpp
@@ -5,8 +5,84 @@
 #include "K2Node_Self.h"
 #include "K2Node_ConstructObjectFromClass.h"
 #include "K2Node_Knot.h"
+#include "K2Node_MacroInstance.h"
+#include "K2Node_FunctionResult.h"
 #include "EdGraphSchema_K2.h"
+#include "Engine/Blueprint.h"
 #include "Json.h"
+
+namespace
+{
+	UEdGraph* ResolveMacroGraph(const FString& MacroBlueprintPath, const FString& MacroName)
+	{
+		if (MacroName.IsEmpty())
+		{
+			return nullptr;
+		}
+
+		UBlueprint* MacroBlueprint = LoadObject<UBlueprint>(nullptr, *MacroBlueprintPath);
+		if (!MacroBlueprint)
+		{
+			return nullptr;
+		}
+
+		for (UEdGraph* MacroGraph : MacroBlueprint->MacroGraphs)
+		{
+			if (MacroGraph && MacroGraph->GetName().Equals(MacroName, ESearchCase::IgnoreCase))
+			{
+				return MacroGraph;
+			}
+		}
+
+		return nullptr;
+	}
+
+	FString NormalizeStandardMacroName(const FString& MacroName)
+	{
+		FString CompactMacroName = MacroName;
+		CompactMacroName.ReplaceInline(TEXT("_"), TEXT(""));
+		CompactMacroName.ReplaceInline(TEXT("-"), TEXT(""));
+		CompactMacroName.ReplaceInline(TEXT(" "), TEXT(""));
+
+		if (CompactMacroName.Equals(TEXT("ForEach"), ESearchCase::IgnoreCase) ||
+			CompactMacroName.Equals(TEXT("ForEachLoop"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("ForEachLoop");
+		}
+
+		if (CompactMacroName.Equals(TEXT("ForEachWithBreak"), ESearchCase::IgnoreCase) ||
+			CompactMacroName.Equals(TEXT("ForEachLoopWithBreak"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("ForEachLoopWithBreak");
+		}
+
+		if (CompactMacroName.Equals(TEXT("ReverseForEach"), ESearchCase::IgnoreCase) ||
+			CompactMacroName.Equals(TEXT("ReverseForEachLoop"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("ReverseForEachLoop");
+		}
+
+		if (CompactMacroName.Equals(TEXT("For"), ESearchCase::IgnoreCase) ||
+			CompactMacroName.Equals(TEXT("ForLoop"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("ForLoop");
+		}
+
+		if (CompactMacroName.Equals(TEXT("ForWithBreak"), ESearchCase::IgnoreCase) ||
+			CompactMacroName.Equals(TEXT("ForLoopWithBreak"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("ForLoopWithBreak");
+		}
+
+		if (CompactMacroName.Equals(TEXT("While"), ESearchCase::IgnoreCase) ||
+			CompactMacroName.Equals(TEXT("WhileLoop"), ESearchCase::IgnoreCase))
+		{
+			return TEXT("WhileLoop");
+		}
+
+		return MacroName;
+	}
+}
 
 UK2Node* FSpecializedNodeCreator::CreateGetDataTableRowNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
 {
@@ -132,4 +208,97 @@ UK2Node* FSpecializedNodeCreator::CreateKnotNode(UEdGraph* Graph, const TSharedP
 	FNodeCreatorUtils::InitializeK2Node(KnotNode, Graph);
 
 	return KnotNode;
+}
+
+UK2Node* FSpecializedNodeCreator::CreateMacroInstanceNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
+{
+	if (!Graph || !Params.IsValid())
+	{
+		return nullptr;
+	}
+
+	FString MacroName;
+	if (!Params->TryGetStringField(TEXT("macro_name"), MacroName))
+	{
+		if (!Params->TryGetStringField(TEXT("target_function"), MacroName))
+		{
+			if (!Params->TryGetStringField(TEXT("macro_type"), MacroName))
+			{
+				Params->TryGetStringField(TEXT("standard_macro"), MacroName);
+			}
+		}
+	}
+	MacroName = NormalizeStandardMacroName(MacroName);
+
+	FString MacroBlueprintPath = TEXT("/Engine/EditorBlueprintResources/StandardMacros.StandardMacros");
+	if (!Params->TryGetStringField(TEXT("macro_blueprint"), MacroBlueprintPath))
+	{
+		Params->TryGetStringField(TEXT("target_blueprint"), MacroBlueprintPath);
+	}
+
+	UEdGraph* MacroGraph = ResolveMacroGraph(MacroBlueprintPath, MacroName);
+	if (!MacroGraph)
+	{
+		return nullptr;
+	}
+
+	UK2Node_MacroInstance* MacroNode = NewObject<UK2Node_MacroInstance>(Graph);
+	if (!MacroNode)
+	{
+		return nullptr;
+	}
+
+	MacroNode->SetMacroGraph(MacroGraph);
+
+	double PosX, PosY;
+	FNodeCreatorUtils::ExtractNodePosition(Params, PosX, PosY);
+	MacroNode->NodePosX = static_cast<int32>(PosX);
+	MacroNode->NodePosY = static_cast<int32>(PosY);
+
+	Graph->AddNode(MacroNode, true, false);
+	FNodeCreatorUtils::InitializeK2Node(MacroNode, Graph);
+
+	return MacroNode;
+}
+
+UK2Node* FSpecializedNodeCreator::CreateFunctionResultNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
+{
+	if (!Graph || !Params.IsValid())
+	{
+		return nullptr;
+	}
+
+	UK2Node_FunctionResult* TemplateResult = nullptr;
+	for (UEdGraphNode* ExistingNode : Graph->Nodes)
+	{
+		if (UK2Node_FunctionResult* ExistingResult = Cast<UK2Node_FunctionResult>(ExistingNode))
+		{
+			TemplateResult = ExistingResult;
+			break;
+		}
+	}
+
+	if (!TemplateResult)
+	{
+		return nullptr;
+	}
+
+	UK2Node_FunctionResult* ResultNode = NewObject<UK2Node_FunctionResult>(Graph);
+	if (!ResultNode)
+	{
+		return nullptr;
+	}
+
+	ResultNode->FunctionReference = TemplateResult->FunctionReference;
+	ResultNode->UserDefinedPins = TemplateResult->UserDefinedPins;
+
+	double PosX, PosY;
+	FNodeCreatorUtils::ExtractNodePosition(Params, PosX, PosY);
+	ResultNode->NodePosX = static_cast<int32>(PosX);
+	ResultNode->NodePosY = static_cast<int32>(PosY);
+
+	Graph->AddNode(ResultNode, true, false);
+	FNodeCreatorUtils::InitializeK2Node(ResultNode, Graph);
+
+	return ResultNode;
 }

--- a/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/Nodes/UtilityNodes.cpp
+++ b/UnrealMCP/Source/UnrealMCP/Private/Commands/BlueprintGraph/Nodes/UtilityNodes.cpp
@@ -3,9 +3,99 @@
 #include "K2Node_CallFunction.h"
 #include "K2Node_Select.h"
 #include "K2Node_SpawnActorFromClass.h"
+#include "Blueprint/SlateBlueprintLibrary.h"
+#include "Blueprint/WidgetBlueprintLibrary.h"
+#include "Blueprint/WidgetLayoutLibrary.h"
 #include "EdGraphSchema_K2.h"
+#include "Engine/Blueprint.h"
+#include "Kismet/GameplayStatics.h"
+#include "Kismet/KismetInputLibrary.h"
+#include "Kismet/KismetMathLibrary.h"
 #include "Kismet/KismetSystemLibrary.h"
 #include "Json.h"
+
+namespace
+{
+UClass* ResolveFunctionOwnerClass(const FString& ClassName)
+{
+	if (ClassName.IsEmpty())
+	{
+		return nullptr;
+	}
+
+	if (UClass* TargetClass = Cast<UClass>(StaticFindObject(UClass::StaticClass(), nullptr, *ClassName)))
+	{
+		return TargetClass;
+	}
+
+	if (UClass* TargetClass = LoadObject<UClass>(nullptr, *ClassName))
+	{
+		return TargetClass;
+	}
+
+	if (UBlueprint* TargetBlueprint = LoadObject<UBlueprint>(nullptr, *ClassName))
+	{
+		return TargetBlueprint->GeneratedClass;
+	}
+
+	if (ClassName.Contains(TEXT("KismetInputLibrary")) || ClassName.Equals(TEXT("KismetInputLibrary"), ESearchCase::IgnoreCase))
+	{
+		return UKismetInputLibrary::StaticClass();
+	}
+	if (ClassName.Contains(TEXT("KismetMathLibrary")) || ClassName.Equals(TEXT("KismetMathLibrary"), ESearchCase::IgnoreCase))
+	{
+		return UKismetMathLibrary::StaticClass();
+	}
+	if (ClassName.Contains(TEXT("KismetSystemLibrary")) || ClassName.Equals(TEXT("KismetSystemLibrary"), ESearchCase::IgnoreCase))
+	{
+		return UKismetSystemLibrary::StaticClass();
+	}
+	if (ClassName.Contains(TEXT("WidgetBlueprintLibrary")) || ClassName.Equals(TEXT("WidgetBlueprintLibrary"), ESearchCase::IgnoreCase))
+	{
+		return UWidgetBlueprintLibrary::StaticClass();
+	}
+	if (ClassName.Contains(TEXT("WidgetLayoutLibrary")) || ClassName.Equals(TEXT("WidgetLayoutLibrary"), ESearchCase::IgnoreCase))
+	{
+		return UWidgetLayoutLibrary::StaticClass();
+	}
+	if (ClassName.Contains(TEXT("SlateBlueprintLibrary")) || ClassName.Equals(TEXT("SlateBlueprintLibrary"), ESearchCase::IgnoreCase))
+	{
+		return USlateBlueprintLibrary::StaticClass();
+	}
+	if (ClassName.Contains(TEXT("GameplayStatics")) || ClassName.Equals(TEXT("GameplayStatics"), ESearchCase::IgnoreCase))
+	{
+		return UGameplayStatics::StaticClass();
+	}
+
+	return nullptr;
+}
+
+UFunction* FindCommonBlueprintFunction(const FName FunctionName)
+{
+	UClass* CommonClasses[] = {
+		UKismetSystemLibrary::StaticClass(),
+		UKismetMathLibrary::StaticClass(),
+		UKismetInputLibrary::StaticClass(),
+		UWidgetBlueprintLibrary::StaticClass(),
+		UWidgetLayoutLibrary::StaticClass(),
+		USlateBlueprintLibrary::StaticClass(),
+		UGameplayStatics::StaticClass()
+	};
+
+	for (UClass* CommonClass : CommonClasses)
+	{
+		if (CommonClass)
+		{
+			if (UFunction* Function = CommonClass->FindFunctionByName(FunctionName))
+			{
+				return Function;
+			}
+		}
+	}
+
+	return nullptr;
+}
+}
 
 UK2Node* FUtilityNodeCreator::CreatePrintNode(UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params)
 {
@@ -79,7 +169,16 @@ UK2Node* FUtilityNodeCreator::CreateCallFunctionNode(UEdGraph* Graph, const TSha
 	FString ClassName;
 	if (Params->TryGetStringField(TEXT("target_class"), ClassName))
 	{
-		UClass* TargetClass = Cast<UClass>(StaticFindObject(UClass::StaticClass(), nullptr, *ClassName));
+		UClass* TargetClass = ResolveFunctionOwnerClass(ClassName);
+		if (TargetClass)
+		{
+			TargetFunc = TargetClass->FindFunctionByName(FName(*TargetFunction));
+		}
+	}
+	else if (Params->TryGetStringField(TEXT("target_blueprint"), ClassName))
+	{
+		UClass* TargetClass = ResolveFunctionOwnerClass(ClassName);
+
 		if (TargetClass)
 		{
 			TargetFunc = TargetClass->FindFunctionByName(FName(*TargetFunction));
@@ -88,7 +187,12 @@ UK2Node* FUtilityNodeCreator::CreateCallFunctionNode(UEdGraph* Graph, const TSha
 	else
 	{
 		// Try common Unreal classes
-		TargetFunc = UKismetSystemLibrary::StaticClass()->FindFunctionByName(FName(*TargetFunction));
+		TargetFunc = FindCommonBlueprintFunction(FName(*TargetFunction));
+	}
+
+	if (!TargetFunc)
+	{
+		TargetFunc = FindCommonBlueprintFunction(FName(*TargetFunction));
 	}
 
 	if (!TargetFunc)

--- a/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPBlueprintCommands.cpp
+++ b/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPBlueprintCommands.cpp
@@ -27,7 +27,82 @@
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "GameFramework/Actor.h"
 #include "GameFramework/Pawn.h"
+#include "Blueprint/UserWidget.h"
+#include "Blueprint/WidgetTree.h"
+#include "Components/Widget.h"
 #include "Kismet/GameplayStatics.h"
+#include "Misc/PackageName.h"
+#include "UObject/SavePackage.h"
+#include "WidgetBlueprint.h"
+
+namespace
+{
+bool SaveBlueprintAsset(UBlueprint* Blueprint)
+{
+    if (!Blueprint)
+    {
+        return false;
+    }
+
+    Blueprint->MarkPackageDirty();
+    FKismetEditorUtilities::CompileBlueprint(Blueprint);
+
+    const FString PackageName = FPackageName::ObjectPathToPackageName(Blueprint->GetPathName());
+    const FString Filename = FPackageName::LongPackageNameToFilename(PackageName, FPackageName::GetAssetPackageExtension());
+    FSavePackageArgs SaveArgs;
+    SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+    SaveArgs.SaveFlags = SAVE_NoError;
+    return UPackage::SavePackage(Blueprint->GetOutermost(), Blueprint, *Filename, SaveArgs);
+}
+
+UClass* ResolveParentClassForBlueprint(const FString& ParentClass)
+{
+    if (ParentClass.IsEmpty())
+    {
+        return nullptr;
+    }
+
+    if (ParentClass == TEXT("UserWidget") || ParentClass == TEXT("UUserWidget") || ParentClass == TEXT("/Script/UMG.UserWidget"))
+    {
+        return UUserWidget::StaticClass();
+    }
+    if (ParentClass == TEXT("Actor") || ParentClass == TEXT("AActor") || ParentClass == TEXT("/Script/Engine.Actor"))
+    {
+        return AActor::StaticClass();
+    }
+    if (ParentClass == TEXT("Pawn") || ParentClass == TEXT("APawn") || ParentClass == TEXT("/Script/Engine.Pawn"))
+    {
+        return APawn::StaticClass();
+    }
+
+    if (UClass* LoadedClass = LoadClass<UObject>(nullptr, *ParentClass))
+    {
+        return LoadedClass;
+    }
+
+    if (UClass* FoundClass = FindObject<UClass>(nullptr, *ParentClass))
+    {
+        return FoundClass;
+    }
+
+    if (!ParentClass.Contains(TEXT(".")) && !ParentClass.StartsWith(TEXT("/Script/")))
+    {
+        const FString EngineClassPath = FString::Printf(TEXT("/Script/Engine.%s"), *ParentClass);
+        if (UClass* EngineClass = LoadClass<UObject>(nullptr, *EngineClassPath))
+        {
+            return EngineClass;
+        }
+
+        const FString UMGClassPath = FString::Printf(TEXT("/Script/UMG.%s"), *ParentClass);
+        if (UClass* UMGClass = LoadClass<UObject>(nullptr, *UMGClassPath))
+        {
+            return UMGClass;
+        }
+    }
+
+    return nullptr;
+}
+}
 
 FEpicUnrealMCPBlueprintCommands::FEpicUnrealMCPBlueprintCommands()
 {
@@ -38,6 +113,14 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintCommands::HandleCommand(const FSt
     if (CommandType == TEXT("create_blueprint"))
     {
         return HandleCreateBlueprint(Params);
+    }
+    else if (CommandType == TEXT("reparent_blueprint"))
+    {
+        return HandleReparentBlueprint(Params);
+    }
+    else if (CommandType == TEXT("set_widget_is_variable"))
+    {
+        return HandleSetWidgetIsVariable(Params);
     }
     else if (CommandType == TEXT("add_component_to_blueprint"))
     {
@@ -198,6 +281,158 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintCommands::HandleCreateBlueprint(c
     }
 
     return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Failed to create blueprint"));
+}
+
+TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintCommands::HandleReparentBlueprint(const TSharedPtr<FJsonObject>& Params)
+{
+    FString BlueprintPath;
+    if (!Params->TryGetStringField(TEXT("blueprint_path"), BlueprintPath)
+        && !Params->TryGetStringField(TEXT("blueprint_name"), BlueprintPath))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'blueprint_path' or 'blueprint_name' parameter"));
+    }
+
+    FString ParentClassName;
+    if (!Params->TryGetStringField(TEXT("parent_class"), ParentClassName))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'parent_class' parameter"));
+    }
+
+    UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *BlueprintPath);
+    if (!Blueprint)
+    {
+        Blueprint = FEpicUnrealMCPCommonUtils::FindBlueprint(BlueprintPath);
+    }
+    if (!Blueprint)
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Blueprint not found: %s"), *BlueprintPath));
+    }
+
+    UClass* NewParentClass = ResolveParentClassForBlueprint(ParentClassName);
+    if (!NewParentClass)
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Parent class not found: %s"), *ParentClassName));
+    }
+    if (!FKismetEditorUtilities::CanCreateBlueprintOfClass(NewParentClass))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Class cannot be used as a Blueprint parent: %s"), *NewParentClass->GetName()));
+    }
+
+    const FString OldParentName = Blueprint->ParentClass ? Blueprint->ParentClass->GetName() : TEXT("None");
+    Blueprint->Modify();
+    Blueprint->ParentClass = NewParentClass;
+    FBlueprintEditorUtils::RefreshAllNodes(Blueprint);
+    FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
+    const bool bSaved = SaveBlueprintAsset(Blueprint);
+
+    TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+    Result->SetBoolField(TEXT("success"), true);
+    Result->SetStringField(TEXT("blueprint_path"), Blueprint->GetPathName());
+    Result->SetStringField(TEXT("old_parent_class"), OldParentName);
+    Result->SetStringField(TEXT("new_parent_class"), NewParentClass->GetName());
+    Result->SetBoolField(TEXT("saved"), bSaved);
+    return Result;
+}
+
+TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintCommands::HandleSetWidgetIsVariable(const TSharedPtr<FJsonObject>& Params)
+{
+    FString BlueprintPath;
+    if (!Params->TryGetStringField(TEXT("blueprint_path"), BlueprintPath)
+        && !Params->TryGetStringField(TEXT("blueprint_name"), BlueprintPath))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'blueprint_path' or 'blueprint_name' parameter"));
+    }
+
+    bool bIsVariable = true;
+    Params->TryGetBoolField(TEXT("is_variable"), bIsVariable);
+
+    TArray<FString> WidgetNames;
+    FString SingleWidgetName;
+    if (Params->TryGetStringField(TEXT("widget_name"), SingleWidgetName))
+    {
+        WidgetNames.Add(SingleWidgetName);
+    }
+
+    const TArray<TSharedPtr<FJsonValue>>* WidgetNameValues = nullptr;
+    if (Params->TryGetArrayField(TEXT("widget_names"), WidgetNameValues))
+    {
+        for (const TSharedPtr<FJsonValue>& Value : *WidgetNameValues)
+        {
+            FString WidgetName;
+            if (Value.IsValid() && Value->TryGetString(WidgetName) && !WidgetName.IsEmpty())
+            {
+                WidgetNames.Add(WidgetName);
+            }
+        }
+    }
+
+    if (WidgetNames.Num() == 0)
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'widget_name' or non-empty 'widget_names' parameter"));
+    }
+
+    UWidgetBlueprint* WidgetBlueprint = Cast<UWidgetBlueprint>(LoadObject<UBlueprint>(nullptr, *BlueprintPath));
+    if (!WidgetBlueprint)
+    {
+        WidgetBlueprint = Cast<UWidgetBlueprint>(FEpicUnrealMCPCommonUtils::FindBlueprint(BlueprintPath));
+    }
+    if (!WidgetBlueprint || !WidgetBlueprint->WidgetTree)
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Widget Blueprint not found: %s"), *BlueprintPath));
+    }
+
+    TArray<TSharedPtr<FJsonValue>> ChangedWidgets;
+    TArray<TSharedPtr<FJsonValue>> MissingWidgets;
+    TArray<TSharedPtr<FJsonValue>> AvailableWidgets;
+
+    TArray<UWidget*> WidgetsInTree;
+    WidgetBlueprint->WidgetTree->ForEachWidget([&WidgetsInTree, &AvailableWidgets](UWidget* Widget)
+    {
+        if (Widget)
+        {
+            WidgetsInTree.Add(Widget);
+            AvailableWidgets.Add(MakeShared<FJsonValueString>(Widget->GetName()));
+        }
+    });
+
+    WidgetBlueprint->Modify();
+    for (const FString& WidgetName : WidgetNames)
+    {
+        UWidget* Widget = WidgetBlueprint->WidgetTree->FindWidget(FName(*WidgetName));
+        if (!Widget)
+        {
+            for (UWidget* CandidateWidget : WidgetsInTree)
+            {
+                if (CandidateWidget && CandidateWidget->GetName().Equals(WidgetName, ESearchCase::IgnoreCase))
+                {
+                    Widget = CandidateWidget;
+                    break;
+                }
+            }
+        }
+        if (!Widget)
+        {
+            MissingWidgets.Add(MakeShared<FJsonValueString>(WidgetName));
+            continue;
+        }
+
+        Widget->Modify();
+        Widget->bIsVariable = bIsVariable;
+        ChangedWidgets.Add(MakeShared<FJsonValueString>(WidgetName));
+    }
+
+    FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WidgetBlueprint);
+    const bool bSaved = SaveBlueprintAsset(WidgetBlueprint);
+
+    TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+    Result->SetBoolField(TEXT("success"), true);
+    Result->SetStringField(TEXT("blueprint_path"), WidgetBlueprint->GetPathName());
+    Result->SetBoolField(TEXT("is_variable"), bIsVariable);
+    Result->SetArrayField(TEXT("changed_widgets"), ChangedWidgets);
+    Result->SetArrayField(TEXT("missing_widgets"), MissingWidgets);
+    Result->SetArrayField(TEXT("available_widgets"), AvailableWidgets);
+    Result->SetBoolField(TEXT("saved"), bSaved);
+    return Result;
 }
 
 TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintCommands::HandleAddComponentToBlueprint(const TSharedPtr<FJsonObject>& Params)
@@ -392,10 +627,19 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintCommands::HandleCompileBlueprint(
 
     // Compile the blueprint
     FKismetEditorUtilities::CompileBlueprint(Blueprint);
+    Blueprint->MarkPackageDirty();
+
+    const FString PackageName = FPackageName::ObjectPathToPackageName(Blueprint->GetPathName());
+    const FString Filename = FPackageName::LongPackageNameToFilename(PackageName, FPackageName::GetAssetPackageExtension());
+    FSavePackageArgs SaveArgs;
+    SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+    SaveArgs.SaveFlags = SAVE_NoError;
+    const bool bSaved = UPackage::SavePackage(Blueprint->GetOutermost(), Blueprint, *Filename, SaveArgs);
 
     TSharedPtr<FJsonObject> ResultObj = MakeShared<FJsonObject>();
     ResultObj->SetStringField(TEXT("name"), BlueprintName);
     ResultObj->SetBoolField(TEXT("compiled"), true);
+    ResultObj->SetBoolField(TEXT("saved"), bSaved);
     return ResultObj;
 }
 
@@ -1395,6 +1639,15 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintCommands::HandleAnalyzeBlueprintG
                         PinObj->SetStringField(TEXT("type"), Pin->PinType.PinCategory.ToString());
                         PinObj->SetStringField(TEXT("direction"), Pin->Direction == EGPD_Input ? TEXT("Input") : TEXT("Output"));
                         PinObj->SetNumberField(TEXT("connections"), Pin->LinkedTo.Num());
+                        PinObj->SetStringField(TEXT("default_value"), Pin->DefaultValue);
+                        if (Pin->DefaultObject)
+                        {
+                            PinObj->SetStringField(TEXT("default_object"), Pin->DefaultObject->GetPathName());
+                        }
+                        if (!Pin->DefaultTextValue.IsEmpty())
+                        {
+                            PinObj->SetStringField(TEXT("default_text"), Pin->DefaultTextValue.ToString());
+                        }
                         
                         // Record connections for this pin
                         for (UEdGraphPin* LinkedPin : Pin->LinkedTo)

--- a/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPBlueprintGraphCommands.cpp
+++ b/UnrealMCP/Source/UnrealMCP/Private/Commands/EpicUnrealMCPBlueprintGraphCommands.cpp
@@ -8,6 +8,259 @@
 #include "Commands/BlueprintGraph/NodePropertyManager.h"
 #include "Commands/BlueprintGraph/Function/FunctionManager.h"
 #include "Commands/BlueprintGraph/Function/FunctionIO.h"
+#include "Engine/Blueprint.h"
+#include "EdGraph/EdGraph.h"
+#include "EdGraph/EdGraphNode.h"
+#include "EdGraphSchema_K2.h"
+#include "K2Node_Event.h"
+#include "K2Node_FunctionEntry.h"
+#include "K2Node_FunctionResult.h"
+#include "Kismet2/BlueprintEditorUtils.h"
+#include "Kismet2/KismetEditorUtilities.h"
+#include "Misc/PackageName.h"
+#include "Misc/Paths.h"
+#include "UObject/SavePackage.h"
+
+namespace
+{
+TSharedPtr<FJsonObject> CloneJsonObject(const TSharedPtr<FJsonObject>& Source)
+{
+    TSharedPtr<FJsonObject> Clone = MakeShared<FJsonObject>();
+    if (Source.IsValid())
+    {
+        Clone->Values = Source->Values;
+    }
+    return Clone;
+}
+
+void CopyJsonFieldIfMissing(const TSharedPtr<FJsonObject>& Source, const TCHAR* FieldName, const TSharedPtr<FJsonObject>& Target)
+{
+    if (!Source.IsValid() || !Target.IsValid() || Target->HasField(FieldName))
+    {
+        return;
+    }
+
+    const TSharedPtr<FJsonValue>* Value = Source->Values.Find(FieldName);
+    if (Value && Value->IsValid())
+    {
+        Target->SetField(FieldName, *Value);
+    }
+}
+
+bool JsonBoolWithDefault(const TSharedPtr<FJsonObject>& Object, const TCHAR* FieldName, const bool DefaultValue)
+{
+    bool Value = DefaultValue;
+    if (Object.IsValid())
+    {
+        Object->TryGetBoolField(FieldName, Value);
+    }
+    return Value;
+}
+
+UBlueprint* LoadGraphCommandBlueprint(const FString& BlueprintName)
+{
+    if (UBlueprint* Blueprint = FEpicUnrealMCPCommonUtils::FindBlueprint(BlueprintName))
+    {
+        return Blueprint;
+    }
+
+    FString BlueprintPath = BlueprintName;
+    if (!BlueprintPath.StartsWith(TEXT("/")))
+    {
+        BlueprintPath = TEXT("/Game/Blueprints/") + BlueprintPath;
+    }
+    if (!BlueprintPath.Contains(TEXT(".")))
+    {
+        BlueprintPath += TEXT(".") + FPaths::GetBaseFilename(BlueprintPath);
+    }
+
+    return LoadObject<UBlueprint>(nullptr, *BlueprintPath);
+}
+
+UEdGraph* FindGraphForBatchCommand(UBlueprint* Blueprint, const FString& FunctionName)
+{
+    if (!Blueprint)
+    {
+        return nullptr;
+    }
+
+    if (FunctionName.IsEmpty() || FunctionName.Equals(TEXT("EventGraph"), ESearchCase::IgnoreCase))
+    {
+        return Blueprint->UbergraphPages.Num() > 0 ? Blueprint->UbergraphPages[0] : nullptr;
+    }
+
+    for (UEdGraph* FunctionGraph : Blueprint->FunctionGraphs)
+    {
+        if (FunctionGraph &&
+            (FunctionGraph->GetName().Equals(FunctionName, ESearchCase::IgnoreCase) ||
+             FunctionGraph->GetFName().ToString().Equals(FunctionName, ESearchCase::IgnoreCase)))
+        {
+            return FunctionGraph;
+        }
+    }
+
+    return nullptr;
+}
+
+TSharedPtr<FJsonObject> ClearGraphBody(const TSharedPtr<FJsonObject>& Params)
+{
+    FString BlueprintName;
+    if (!Params->TryGetStringField(TEXT("blueprint_name"), BlueprintName))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'blueprint_name' parameter"));
+    }
+
+    FString FunctionName;
+    Params->TryGetStringField(TEXT("function_name"), FunctionName);
+
+    UBlueprint* Blueprint = LoadGraphCommandBlueprint(BlueprintName);
+    if (!Blueprint)
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Blueprint not found: %s"), *BlueprintName));
+    }
+
+    UEdGraph* Graph = FindGraphForBatchCommand(Blueprint, FunctionName);
+    if (!Graph)
+    {
+        const FString ErrorMessage = FunctionName.IsEmpty()
+            ? FString(TEXT("Blueprint has no event graph"))
+            : FString::Printf(TEXT("Function graph not found: %s"), *FunctionName);
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(ErrorMessage);
+    }
+
+    const bool bKeepFunctionEntry = JsonBoolWithDefault(Params, TEXT("keep_function_entry"), true);
+    const bool bKeepFunctionResult = JsonBoolWithDefault(Params, TEXT("keep_function_result"), true);
+    const bool bKeepEventNodes = JsonBoolWithDefault(Params, TEXT("keep_event_nodes"), false);
+    const bool bBreakKeptLinks = JsonBoolWithDefault(Params, TEXT("break_kept_links"), true);
+
+    Blueprint->Modify();
+    Graph->Modify();
+
+    int32 RemovedCount = 0;
+    int32 KeptCount = 0;
+    TArray<UEdGraphNode*> Nodes = Graph->Nodes;
+
+    for (UEdGraphNode* Node : Nodes)
+    {
+        if (!Node)
+        {
+            continue;
+        }
+
+        const bool bKeepNode =
+            (bKeepFunctionEntry && Cast<UK2Node_FunctionEntry>(Node)) ||
+            (bKeepFunctionResult && Cast<UK2Node_FunctionResult>(Node)) ||
+            (bKeepEventNodes && Cast<UK2Node_Event>(Node));
+
+        Node->Modify();
+        if (bKeepNode)
+        {
+            if (bBreakKeptLinks)
+            {
+                Node->BreakAllNodeLinks();
+            }
+            ++KeptCount;
+            continue;
+        }
+
+        Node->BreakAllNodeLinks();
+        Graph->RemoveNode(Node);
+        ++RemovedCount;
+    }
+
+    Graph->NotifyGraphChanged();
+    FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
+
+    TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+    Result->SetBoolField(TEXT("success"), true);
+    Result->SetNumberField(TEXT("removed_nodes"), RemovedCount);
+    Result->SetNumberField(TEXT("kept_nodes"), KeptCount);
+    Result->SetStringField(TEXT("graph_name"), Graph->GetName());
+    return Result;
+}
+
+FString ResolveNodeId(const TMap<FString, FString>& Aliases, const FString& Reference)
+{
+    if (const FString* NodeId = Aliases.Find(Reference))
+    {
+        return *NodeId;
+    }
+    return Reference;
+}
+
+bool TryGetAnyStringField(const TSharedPtr<FJsonObject>& Object, const TArray<FString>& FieldNames, FString& OutValue)
+{
+    if (!Object.IsValid())
+    {
+        return false;
+    }
+
+    for (const FString& FieldName : FieldNames)
+    {
+        if (Object->TryGetStringField(FieldName, OutValue))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+TSharedPtr<FJsonObject> BuildAddNodeParams(const TSharedPtr<FJsonObject>& BatchParams, const TSharedPtr<FJsonObject>& Operation)
+{
+    TSharedPtr<FJsonObject> AddParams = MakeShared<FJsonObject>();
+    CopyJsonFieldIfMissing(Operation, TEXT("blueprint_name"), AddParams);
+    CopyJsonFieldIfMissing(BatchParams, TEXT("blueprint_name"), AddParams);
+    CopyJsonFieldIfMissing(Operation, TEXT("node_type"), AddParams);
+
+    const TSharedPtr<FJsonObject>* NodeParamsObject = nullptr;
+    TSharedPtr<FJsonObject> NodeParams = MakeShared<FJsonObject>();
+    if (Operation->TryGetObjectField(TEXT("node_params"), NodeParamsObject) && NodeParamsObject && NodeParamsObject->IsValid())
+    {
+        NodeParams = CloneJsonObject(*NodeParamsObject);
+    }
+
+    const TSet<FString> ReservedFields =
+    {
+        TEXT("op"),
+        TEXT("command"),
+        TEXT("alias"),
+        TEXT("blueprint_name"),
+        TEXT("node_type"),
+        TEXT("node_params")
+    };
+
+    for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : Operation->Values)
+    {
+        if (!ReservedFields.Contains(Pair.Key) && !NodeParams->HasField(Pair.Key))
+        {
+            NodeParams->SetField(Pair.Key, Pair.Value);
+        }
+    }
+
+    CopyJsonFieldIfMissing(BatchParams, TEXT("function_name"), NodeParams);
+    AddParams->SetObjectField(TEXT("node_params"), NodeParams);
+    return AddParams;
+}
+
+bool SaveGraphBlueprint(UBlueprint* Blueprint)
+{
+    if (!Blueprint)
+    {
+        return false;
+    }
+
+    Blueprint->MarkPackageDirty();
+    FKismetEditorUtilities::CompileBlueprint(Blueprint);
+
+    const FString PackageName = FPackageName::ObjectPathToPackageName(Blueprint->GetPathName());
+    const FString Filename = FPackageName::LongPackageNameToFilename(PackageName, FPackageName::GetAssetPackageExtension());
+    FSavePackageArgs SaveArgs;
+    SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+    SaveArgs.SaveFlags = SAVE_NoError;
+    return UPackage::SavePackage(Blueprint->GetOutermost(), Blueprint, *Filename, SaveArgs);
+}
+}
 
 FEpicUnrealMCPBlueprintGraphCommands::FEpicUnrealMCPBlueprintGraphCommands()
 {
@@ -23,9 +276,52 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleCommand(cons
     {
         return HandleAddBlueprintNode(Params);
     }
+    else if (CommandType == TEXT("execute_blueprint_graph_batch") ||
+             CommandType == TEXT("batch_blueprint_graph_commands"))
+    {
+        return HandleBatchGraphCommands(Params);
+    }
+    else if (CommandType == TEXT("add_set_fields_in_struct_node") ||
+             CommandType == TEXT("add_set_struct_fields_node"))
+    {
+        return HandleAddBlueprintNodeAlias(Params, TEXT("SetFieldsInStruct"));
+    }
+    else if (CommandType == TEXT("add_macro_instance_node") ||
+             CommandType == TEXT("add_standard_macro_node"))
+    {
+        return HandleAddBlueprintNodeAlias(Params, TEXT("MacroInstance"));
+    }
+    else if (CommandType == TEXT("add_for_each_loop_node"))
+    {
+        return HandleAddBlueprintNodeAlias(Params, TEXT("ForEachLoop"));
+    }
+    else if (CommandType == TEXT("add_for_each_loop_with_break_node"))
+    {
+        return HandleAddBlueprintNodeAlias(Params, TEXT("ForEachLoopWithBreak"));
+    }
+    else if (CommandType == TEXT("add_reverse_for_each_loop_node"))
+    {
+        return HandleAddBlueprintNodeAlias(Params, TEXT("ReverseForEachLoop"));
+    }
+    else if (CommandType == TEXT("add_for_loop_node"))
+    {
+        return HandleAddBlueprintNodeAlias(Params, TEXT("ForLoop"));
+    }
+    else if (CommandType == TEXT("add_for_loop_with_break_node"))
+    {
+        return HandleAddBlueprintNodeAlias(Params, TEXT("ForLoopWithBreak"));
+    }
+    else if (CommandType == TEXT("add_while_loop_node"))
+    {
+        return HandleAddBlueprintNodeAlias(Params, TEXT("WhileLoop"));
+    }
     else if (CommandType == TEXT("connect_nodes"))
     {
         return HandleConnectNodes(Params);
+    }
+    else if (CommandType == TEXT("break_pin_links"))
+    {
+        return HandleBreakPinLinks(Params);
     }
     else if (CommandType == TEXT("create_variable"))
     {
@@ -50,6 +346,10 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleCommand(cons
     else if (CommandType == TEXT("create_function"))
     {
         return HandleCreateFunction(Params);
+    }
+    else if (CommandType == TEXT("create_override_function"))
+    {
+        return HandleCreateOverrideFunction(Params);
     }
     else if (CommandType == TEXT("add_function_input"))
     {
@@ -92,6 +392,20 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleAddBlueprint
     return FBlueprintNodeManager::AddNode(Params);
 }
 
+TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleAddBlueprintNodeAlias(const TSharedPtr<FJsonObject>& Params, const FString& NodeType)
+{
+    if (!Params.IsValid())
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Invalid parameters"));
+    }
+
+    TSharedPtr<FJsonObject> AliasedParams = MakeShared<FJsonObject>();
+    AliasedParams->Values = Params->Values;
+    AliasedParams->SetStringField(TEXT("node_type"), NodeType);
+
+    return HandleAddBlueprintNode(AliasedParams);
+}
+
 TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleConnectNodes(const TSharedPtr<FJsonObject>& Params)
 {
     // Get required parameters
@@ -130,6 +444,33 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleConnectNodes
 
     // Use the BPConnector to connect the nodes
     return FBPConnector::ConnectNodes(Params);
+}
+
+TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleBreakPinLinks(const TSharedPtr<FJsonObject>& Params)
+{
+    FString BlueprintName;
+    if (!Params->TryGetStringField(TEXT("blueprint_name"), BlueprintName))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'blueprint_name' parameter"));
+    }
+
+    FString NodeId;
+    if (!Params->TryGetStringField(TEXT("node_id"), NodeId))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'node_id' parameter"));
+    }
+
+    FString PinName;
+    if (!Params->TryGetStringField(TEXT("pin_name"), PinName))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'pin_name' parameter"));
+    }
+
+    UE_LOG(LogTemp, Display,
+        TEXT("FEpicUnrealMCPBlueprintGraphCommands::HandleBreakPinLinks: Breaking links on %s.%s in blueprint '%s'"),
+        *NodeId, *PinName, *BlueprintName);
+
+    return FBPConnector::BreakPinLinks(Params);
 }
 
 TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleCreateVariable(const TSharedPtr<FJsonObject>& Params)
@@ -289,6 +630,67 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleCreateFuncti
     return FFunctionManager::CreateFunction(Params);
 }
 
+TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleCreateOverrideFunction(const TSharedPtr<FJsonObject>& Params)
+{
+    FString BlueprintName;
+    if (!Params->TryGetStringField(TEXT("blueprint_name"), BlueprintName))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'blueprint_name' parameter"));
+    }
+
+    FString FunctionName;
+    if (!Params->TryGetStringField(TEXT("function_name"), FunctionName))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'function_name' parameter"));
+    }
+
+    UBlueprint* Blueprint = FEpicUnrealMCPCommonUtils::FindBlueprint(BlueprintName);
+    if (!Blueprint)
+    {
+        Blueprint = LoadObject<UBlueprint>(nullptr, *BlueprintName);
+    }
+    if (!Blueprint)
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Blueprint not found: %s"), *BlueprintName));
+    }
+
+    UFunction* OverrideFunction = nullptr;
+    UClass* OverrideClass = FBlueprintEditorUtils::GetOverrideFunctionClass(Blueprint, FName(*FunctionName), &OverrideFunction);
+    if (!OverrideClass || !OverrideFunction)
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Override function not found: %s"), *FunctionName));
+    }
+
+    for (UEdGraph* ExistingGraph : Blueprint->FunctionGraphs)
+    {
+        if (ExistingGraph && ExistingGraph->GetFName() == FName(*FunctionName))
+        {
+            TSharedPtr<FJsonObject> ExistingResult = MakeShared<FJsonObject>();
+            ExistingResult->SetBoolField(TEXT("success"), true);
+            ExistingResult->SetBoolField(TEXT("created"), false);
+            ExistingResult->SetStringField(TEXT("function_name"), FunctionName);
+            ExistingResult->SetStringField(TEXT("graph_name"), ExistingGraph->GetName());
+            ExistingResult->SetStringField(TEXT("signature_class"), OverrideClass->GetName());
+            return ExistingResult;
+        }
+    }
+
+    Blueprint->Modify();
+    UEdGraph* NewGraph = FBlueprintEditorUtils::CreateNewGraph(Blueprint, FName(*FunctionName), UEdGraph::StaticClass(), UEdGraphSchema_K2::StaticClass());
+    FBlueprintEditorUtils::AddFunctionGraph(Blueprint, NewGraph, false, OverrideClass);
+    FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
+    const bool bSaved = SaveGraphBlueprint(Blueprint);
+
+    TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+    Result->SetBoolField(TEXT("success"), true);
+    Result->SetBoolField(TEXT("created"), true);
+    Result->SetBoolField(TEXT("saved"), bSaved);
+    Result->SetStringField(TEXT("function_name"), FunctionName);
+    Result->SetStringField(TEXT("graph_name"), NewGraph ? NewGraph->GetName() : FunctionName);
+    Result->SetStringField(TEXT("signature_class"), OverrideClass->GetName());
+    return Result;
+}
+
 TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleAddFunctionInput(const TSharedPtr<FJsonObject>& Params)
 {
     FString BlueprintName;
@@ -385,4 +787,272 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleRenameFuncti
         *OldFunctionName, *NewFunctionName, *BlueprintName);
 
     return FFunctionManager::RenameFunction(Params);
+}
+
+TSharedPtr<FJsonObject> FEpicUnrealMCPBlueprintGraphCommands::HandleBatchGraphCommands(const TSharedPtr<FJsonObject>& Params)
+{
+    if (!Params.IsValid())
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Invalid parameters"));
+    }
+
+    const TArray<TSharedPtr<FJsonValue>>* Operations = nullptr;
+    if (!Params->TryGetArrayField(TEXT("operations"), Operations))
+    {
+        return FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'operations' array"));
+    }
+
+    const bool bStopOnError = JsonBoolWithDefault(Params, TEXT("stop_on_error"), true);
+    TMap<FString, FString> NodeAliases;
+    TArray<TSharedPtr<FJsonValue>> Results;
+    bool bAllSucceeded = true;
+
+    for (int32 Index = 0; Index < Operations->Num(); ++Index)
+    {
+        TSharedPtr<FJsonObject> Operation = (*Operations)[Index].IsValid() ? (*Operations)[Index]->AsObject() : nullptr;
+        TSharedPtr<FJsonObject> OperationResult = nullptr;
+        FString OperationName;
+
+        if (!Operation.IsValid())
+        {
+            OperationResult = FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Operation must be a JSON object"));
+        }
+        else if (!Operation->TryGetStringField(TEXT("op"), OperationName) &&
+                 !Operation->TryGetStringField(TEXT("command"), OperationName))
+        {
+            OperationResult = FEpicUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Operation is missing 'op' or 'command'"));
+        }
+        else if (OperationName.Equals(TEXT("add_node"), ESearchCase::IgnoreCase) ||
+                 OperationName.Equals(TEXT("add_blueprint_node"), ESearchCase::IgnoreCase))
+        {
+            OperationResult = HandleAddBlueprintNode(BuildAddNodeParams(Params, Operation));
+
+            bool bOperationSuccess = false;
+            if (OperationResult.IsValid() && OperationResult->TryGetBoolField(TEXT("success"), bOperationSuccess) && bOperationSuccess)
+            {
+                FString Alias;
+                FString NodeId;
+                if (Operation->TryGetStringField(TEXT("alias"), Alias) && OperationResult->TryGetStringField(TEXT("node_id"), NodeId))
+                {
+                    NodeAliases.Add(Alias, NodeId);
+                }
+            }
+        }
+        else if (OperationName.Equals(TEXT("connect"), ESearchCase::IgnoreCase) ||
+                 OperationName.Equals(TEXT("connect_nodes"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> ConnectParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), ConnectParams);
+            CopyJsonFieldIfMissing(Params, TEXT("function_name"), ConnectParams);
+
+            FString SourceReference;
+            FString TargetReference;
+            FString SourcePin;
+            FString TargetPin;
+            if (TryGetAnyStringField(Operation, { TEXT("from"), TEXT("source"), TEXT("source_node"), TEXT("source_node_id") }, SourceReference))
+            {
+                ConnectParams->SetStringField(TEXT("source_node_id"), ResolveNodeId(NodeAliases, SourceReference));
+            }
+            if (TryGetAnyStringField(Operation, { TEXT("to"), TEXT("target"), TEXT("target_node"), TEXT("target_node_id") }, TargetReference))
+            {
+                ConnectParams->SetStringField(TEXT("target_node_id"), ResolveNodeId(NodeAliases, TargetReference));
+            }
+            if (TryGetAnyStringField(Operation, { TEXT("from_pin"), TEXT("source_pin"), TEXT("source_pin_name") }, SourcePin))
+            {
+                ConnectParams->SetStringField(TEXT("source_pin_name"), SourcePin);
+            }
+            if (TryGetAnyStringField(Operation, { TEXT("to_pin"), TEXT("target_pin"), TEXT("target_pin_name") }, TargetPin))
+            {
+                ConnectParams->SetStringField(TEXT("target_pin_name"), TargetPin);
+            }
+            if (!ConnectParams->HasField(TEXT("skip_compile")))
+            {
+                ConnectParams->SetBoolField(TEXT("skip_compile"), true);
+            }
+
+            OperationResult = HandleConnectNodes(ConnectParams);
+        }
+        else if (OperationName.Equals(TEXT("set_property"), ESearchCase::IgnoreCase) ||
+                 OperationName.Equals(TEXT("set_node_property"), ESearchCase::IgnoreCase) ||
+                 OperationName.Equals(TEXT("set_pin_default"), ESearchCase::IgnoreCase) ||
+                 OperationName.Equals(TEXT("set_pin_default_object"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> PropertyParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), PropertyParams);
+            CopyJsonFieldIfMissing(Params, TEXT("function_name"), PropertyParams);
+
+            FString NodeReference;
+            if (TryGetAnyStringField(Operation, { TEXT("node"), TEXT("node_id") }, NodeReference))
+            {
+                PropertyParams->SetStringField(TEXT("node_id"), ResolveNodeId(NodeAliases, NodeReference));
+            }
+
+            if (OperationName.Equals(TEXT("set_pin_default"), ESearchCase::IgnoreCase) ||
+                OperationName.Equals(TEXT("set_pin_default_object"), ESearchCase::IgnoreCase))
+            {
+                FString PinName;
+                if (Operation->TryGetStringField(TEXT("pin"), PinName))
+                {
+                    PropertyParams->SetStringField(TEXT("property_name"),
+                        OperationName.Equals(TEXT("set_pin_default_object"), ESearchCase::IgnoreCase)
+                            ? FString::Printf(TEXT("pin_default_object:%s"), *PinName)
+                            : FString::Printf(TEXT("pin_default:%s"), *PinName));
+                }
+
+                if (!PropertyParams->HasField(TEXT("property_value")))
+                {
+                    if (TSharedPtr<FJsonValue> Value = Operation->TryGetField(TEXT("value")))
+                    {
+                        PropertyParams->SetField(TEXT("property_value"), Value);
+                    }
+                }
+            }
+
+            OperationResult = HandleSetNodeProperty(PropertyParams);
+        }
+        else if (OperationName.Equals(TEXT("break_pin_links"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> BreakParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), BreakParams);
+            CopyJsonFieldIfMissing(Params, TEXT("function_name"), BreakParams);
+
+            FString NodeReference;
+            if (TryGetAnyStringField(Operation, { TEXT("node"), TEXT("node_id") }, NodeReference))
+            {
+                BreakParams->SetStringField(TEXT("node_id"), ResolveNodeId(NodeAliases, NodeReference));
+            }
+
+            OperationResult = HandleBreakPinLinks(BreakParams);
+        }
+        else if (OperationName.Equals(TEXT("delete_node"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> DeleteParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), DeleteParams);
+            CopyJsonFieldIfMissing(Params, TEXT("function_name"), DeleteParams);
+
+            FString NodeReference;
+            if (TryGetAnyStringField(Operation, { TEXT("node"), TEXT("node_id") }, NodeReference))
+            {
+                DeleteParams->SetStringField(TEXT("node_id"), ResolveNodeId(NodeAliases, NodeReference));
+            }
+
+            OperationResult = HandleDeleteNode(DeleteParams);
+        }
+        else if (OperationName.Equals(TEXT("clear_graph"), ESearchCase::IgnoreCase) ||
+                 OperationName.Equals(TEXT("clear_graph_body"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> ClearParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), ClearParams);
+            CopyJsonFieldIfMissing(Params, TEXT("function_name"), ClearParams);
+            OperationResult = ClearGraphBody(ClearParams);
+        }
+        else if (OperationName.Equals(TEXT("create_variable"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> CreateParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), CreateParams);
+            OperationResult = HandleCreateVariable(CreateParams);
+        }
+        else if (OperationName.Equals(TEXT("set_blueprint_variable_properties"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> VariableParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), VariableParams);
+            OperationResult = HandleSetVariableProperties(VariableParams);
+        }
+        else if (OperationName.Equals(TEXT("create_function"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> FunctionParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), FunctionParams);
+            OperationResult = HandleCreateFunction(FunctionParams);
+        }
+        else if (OperationName.Equals(TEXT("create_override_function"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> FunctionParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), FunctionParams);
+            OperationResult = HandleCreateOverrideFunction(FunctionParams);
+        }
+        else if (OperationName.Equals(TEXT("add_function_input"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> InputParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), InputParams);
+            OperationResult = HandleAddFunctionInput(InputParams);
+        }
+        else if (OperationName.Equals(TEXT("add_function_output"), ESearchCase::IgnoreCase))
+        {
+            TSharedPtr<FJsonObject> OutputParams = CloneJsonObject(Operation);
+            CopyJsonFieldIfMissing(Params, TEXT("blueprint_name"), OutputParams);
+            OperationResult = HandleAddFunctionOutput(OutputParams);
+        }
+        else
+        {
+            OperationResult = FEpicUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Unsupported batch operation: %s"), *OperationName));
+        }
+
+        bool bOperationSuccess = false;
+        if (!OperationResult.IsValid() || !OperationResult->TryGetBoolField(TEXT("success"), bOperationSuccess) || !bOperationSuccess)
+        {
+            bAllSucceeded = false;
+        }
+
+        TSharedPtr<FJsonObject> WrappedResult = MakeShared<FJsonObject>();
+        WrappedResult->SetNumberField(TEXT("index"), Index);
+        WrappedResult->SetStringField(TEXT("op"), OperationName);
+        WrappedResult->SetBoolField(TEXT("success"), bOperationSuccess);
+        if (OperationResult.IsValid())
+        {
+            WrappedResult->SetObjectField(TEXT("result"), OperationResult);
+            FString ErrorMessage;
+            if (!bOperationSuccess && OperationResult->TryGetStringField(TEXT("error"), ErrorMessage))
+            {
+                WrappedResult->SetStringField(TEXT("error"), ErrorMessage);
+            }
+        }
+        Results.Add(MakeShared<FJsonValueObject>(WrappedResult));
+
+        if (!bOperationSuccess && bStopOnError)
+        {
+            break;
+        }
+    }
+
+    bool bCompile = true;
+    bool bSave = true;
+    Params->TryGetBoolField(TEXT("compile"), bCompile);
+    Params->TryGetBoolField(TEXT("save"), bSave);
+
+    bool bSaved = false;
+    bool bCompiled = false;
+    FString BlueprintName;
+    if ((bCompile || bSave) && Params->TryGetStringField(TEXT("blueprint_name"), BlueprintName))
+    {
+        if (UBlueprint* Blueprint = LoadGraphCommandBlueprint(BlueprintName))
+        {
+            if (bSave)
+            {
+                bSaved = SaveGraphBlueprint(Blueprint);
+                bCompiled = true;
+            }
+            else if (bCompile)
+            {
+                FKismetEditorUtilities::CompileBlueprint(Blueprint);
+                bCompiled = true;
+            }
+        }
+    }
+
+    TSharedPtr<FJsonObject> Response = MakeShared<FJsonObject>();
+    Response->SetBoolField(TEXT("success"), bAllSucceeded);
+    Response->SetArrayField(TEXT("results"), Results);
+    Response->SetBoolField(TEXT("compiled"), bCompiled);
+    Response->SetBoolField(TEXT("saved"), bSaved);
+
+    TArray<TSharedPtr<FJsonValue>> AliasResults;
+    for (const TPair<FString, FString>& Pair : NodeAliases)
+    {
+        TSharedPtr<FJsonObject> AliasObject = MakeShared<FJsonObject>();
+        AliasObject->SetStringField(TEXT("alias"), Pair.Key);
+        AliasObject->SetStringField(TEXT("node_id"), Pair.Value);
+        AliasResults.Add(MakeShared<FJsonValueObject>(AliasObject));
+    }
+    Response->SetArrayField(TEXT("aliases"), AliasResults);
+    return Response;
 }

--- a/UnrealMCP/Source/UnrealMCP/Private/EpicUnrealMCPBridge.cpp
+++ b/UnrealMCP/Source/UnrealMCP/Private/EpicUnrealMCPBridge.cpp
@@ -229,6 +229,8 @@ FString UEpicUnrealMCPBridge::ExecuteCommand(const FString& CommandType, const T
             }
             // Blueprint Commands
             else if (CommandType == TEXT("create_blueprint") ||
+                     CommandType == TEXT("reparent_blueprint") ||
+                     CommandType == TEXT("set_widget_is_variable") ||
                      CommandType == TEXT("add_component_to_blueprint") ||
                      CommandType == TEXT("set_physics_properties") ||
                      CommandType == TEXT("compile_blueprint") ||
@@ -248,13 +250,27 @@ FString UEpicUnrealMCPBridge::ExecuteCommand(const FString& CommandType, const T
             }
             // Blueprint Graph Commands
             else if (CommandType == TEXT("add_blueprint_node") ||
+                     CommandType == TEXT("execute_blueprint_graph_batch") ||
+                     CommandType == TEXT("batch_blueprint_graph_commands") ||
+                     CommandType == TEXT("add_set_fields_in_struct_node") ||
+                     CommandType == TEXT("add_set_struct_fields_node") ||
+                     CommandType == TEXT("add_macro_instance_node") ||
+                     CommandType == TEXT("add_standard_macro_node") ||
+                     CommandType == TEXT("add_for_each_loop_node") ||
+                     CommandType == TEXT("add_for_each_loop_with_break_node") ||
+                     CommandType == TEXT("add_reverse_for_each_loop_node") ||
+                     CommandType == TEXT("add_for_loop_node") ||
+                     CommandType == TEXT("add_for_loop_with_break_node") ||
+                     CommandType == TEXT("add_while_loop_node") ||
                      CommandType == TEXT("connect_nodes") ||
+                     CommandType == TEXT("break_pin_links") ||
                      CommandType == TEXT("create_variable") ||
                      CommandType == TEXT("set_blueprint_variable_properties") ||
                      CommandType == TEXT("add_event_node") ||
                      CommandType == TEXT("delete_node") ||
                      CommandType == TEXT("set_node_property") ||
                      CommandType == TEXT("create_function") ||
+                     CommandType == TEXT("create_override_function") ||
                      CommandType == TEXT("add_function_input") ||
                      CommandType == TEXT("add_function_output") ||
                      CommandType == TEXT("delete_function") ||

--- a/UnrealMCP/Source/UnrealMCP/Private/MCPServerRunnable.cpp
+++ b/UnrealMCP/Source/UnrealMCP/Private/MCPServerRunnable.cpp
@@ -54,6 +54,7 @@ uint32 FMCPServerRunnable::Run()
                 ClientSocket->SetReceiveBufferSize(SocketBufferSize, SocketBufferSize);
                 
                 uint8 Buffer[8192];
+                FString MessageBuffer;
                 while (bRunning)
                 {
                     int32 BytesRead = 0;
@@ -65,20 +66,23 @@ uint32 FMCPServerRunnable::Run()
                             break;
                         }
 
-                        // Convert received data to string
+                        // Convert received data to string and accumulate it. Large graph batches can be bigger than
+                        // one TCP receive, so parsing each chunk independently drops valid commands.
                         Buffer[BytesRead] = '\0';
                         FString ReceivedText = UTF8_TO_TCHAR(Buffer);
                         UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Received: %s"), *ReceivedText);
+                        MessageBuffer.Append(ReceivedText);
 
                         // Parse JSON
                         TSharedPtr<FJsonObject> JsonObject;
-                        TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(ReceivedText);
+                        TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(MessageBuffer);
                         
-                        if (FJsonSerializer::Deserialize(Reader, JsonObject))
+                        if (FJsonSerializer::Deserialize(Reader, JsonObject) && JsonObject.IsValid())
                         {
                             // Get command type
                             FString CommandType;
-                            if (JsonObject->TryGetStringField(TEXT("type"), CommandType))
+                            if (JsonObject->TryGetStringField(TEXT("type"), CommandType) ||
+                                JsonObject->TryGetStringField(TEXT("command"), CommandType))
                             {
                                 UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Executing command: %s"), *CommandType);
 
@@ -126,15 +130,24 @@ uint32 FMCPServerRunnable::Run()
                                     UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Response sent successfully (%d bytes)"),
                                            TotalBytesSent);
                                 }
+
+                                MessageBuffer.Empty();
                             }
                             else
                             {
                                 UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Missing 'type' field in command"));
+                                MessageBuffer.Empty();
                             }
                         }
                         else
                         {
-                            UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Failed to parse JSON from: %s"), *ReceivedText);
+                            UE_LOG(LogTemp, Verbose, TEXT("MCPServerRunnable: Waiting for the rest of a partial JSON command (%d chars buffered)"), MessageBuffer.Len());
+                            if (MessageBuffer.Len() > 4 * 1024 * 1024)
+                            {
+                                UE_LOG(LogTemp, Warning, TEXT("MCPServerRunnable: Dropping oversized incomplete JSON command"));
+                                MessageBuffer.Empty();
+                                break;
+                            }
                         }
                     }
                     else
@@ -366,4 +379,4 @@ void FMCPServerRunnable::ProcessMessage(TSharedPtr<FSocket> Client, const FStrin
 
     UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Response sent successfully (%d bytes)"),
            TotalBytesSent);
-} 
+}

--- a/UnrealMCP/Source/UnrealMCP/Public/Commands/BlueprintGraph/BPConnector.h
+++ b/UnrealMCP/Source/UnrealMCP/Public/Commands/BlueprintGraph/BPConnector.h
@@ -23,6 +23,13 @@ public:
      */
     static TSharedPtr<FJsonObject> ConnectNodes(const TSharedPtr<FJsonObject>& Params);
 
+    /**
+     * Breaks all links on one Blueprint node pin.
+     * @param Params JSON containing blueprint_name, node_id, pin_name, optional pin_direction, optional function_name
+     * @return JSON with success and removed link count
+     */
+    static TSharedPtr<FJsonObject> BreakPinLinks(const TSharedPtr<FJsonObject>& Params);
+
 private:
     /**
      * Finds a node by its ID in the graph

--- a/UnrealMCP/Source/UnrealMCP/Public/Commands/BlueprintGraph/NodeManager.h
+++ b/UnrealMCP/Source/UnrealMCP/Public/Commands/BlueprintGraph/NodeManager.h
@@ -73,6 +73,14 @@ class UNREALMCP_API FBlueprintNodeManager
 		static class UK2Node* CreateCallFunctionNode(class UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params);
 
 		/**
+		 * Create an Enhanced Input Action event node.
+		 * @param Graph - Target graph
+		 * @param Params - Node parameters (must include input_action, optional: pos_x, pos_y)
+		 * @return Created node or nullptr
+		 */
+		static class UK2Node* CreateEnhancedInputActionNode(class UEdGraph* Graph, const TSharedPtr<FJsonObject>& Params);
+
+		/**
 		 * Create a Comparison node (==, >, <, >=, <=)
 		 * @param Graph - Target graph
 		 * @param Params - Node parameters (optional: comparison_type, pos_x, pos_y)

--- a/UnrealMCP/Source/UnrealMCP/Public/Commands/BlueprintGraph/Nodes/DataNodes.h
+++ b/UnrealMCP/Source/UnrealMCP/Public/Commands/BlueprintGraph/Nodes/DataNodes.h
@@ -1,4 +1,4 @@
-// Header for creating data nodes (Variable Get/Set, MakeArray)
+// Header for creating data nodes (Variable Get/Set, arrays, structs)
 
 #pragma once
 
@@ -36,4 +36,44 @@ public:
 	 * @return The created node or nullptr on error
 	 */
 	static UK2Node* CreateMakeArrayNode(UEdGraph* Graph, const TSharedPtr<class FJsonObject>& Params);
+
+	/**
+	 * Creates a Make Struct node (K2Node_MakeStruct)
+	 * @param Graph - The graph to add the node to
+	 * @param Params - JSON parameters containing pos_x, pos_y, struct_path
+	 * @return The created node or nullptr on error
+	 */
+	static UK2Node* CreateMakeStructNode(UEdGraph* Graph, const TSharedPtr<class FJsonObject>& Params);
+
+	/**
+	 * Creates a Break Struct node (K2Node_BreakStruct)
+	 * @param Graph - The graph to add the node to
+	 * @param Params - JSON parameters containing pos_x, pos_y, struct_path
+	 * @return The created node or nullptr on error
+	 */
+	static UK2Node* CreateBreakStructNode(UEdGraph* Graph, const TSharedPtr<class FJsonObject>& Params);
+
+	/**
+	 * Creates a Set Fields In Struct node (K2Node_SetFieldsInStruct)
+	 * @param Graph - The graph to add the node to
+	 * @param Params - JSON parameters containing pos_x, pos_y, struct_path, optional field_names/fields/member_names or show_all_pins
+	 * @return The created node or nullptr on error
+	 */
+	static UK2Node* CreateSetFieldsInStructNode(UEdGraph* Graph, const TSharedPtr<class FJsonObject>& Params);
+
+	/**
+	 * Creates an Array Get node (K2Node_GetArrayItem)
+	 * @param Graph - The graph to add the node to
+	 * @param Params - JSON parameters containing pos_x, pos_y
+	 * @return The created node or nullptr on error
+	 */
+	static UK2Node* CreateArrayGetNode(UEdGraph* Graph, const TSharedPtr<class FJsonObject>& Params);
+
+	/**
+	 * Creates an array library call node (K2Node_CallArrayFunction)
+	 * @param Graph - The graph to add the node to
+	 * @param Params - JSON parameters containing pos_x, pos_y, target_function
+	 * @return The created node or nullptr on error
+	 */
+	static UK2Node* CreateCallArrayFunctionNode(UEdGraph* Graph, const TSharedPtr<class FJsonObject>& Params);
 };

--- a/UnrealMCP/Source/UnrealMCP/Public/Commands/BlueprintGraph/Nodes/SpecializedNodes.h
+++ b/UnrealMCP/Source/UnrealMCP/Public/Commands/BlueprintGraph/Nodes/SpecializedNodes.h
@@ -1,4 +1,4 @@
-// Header for creating specialized nodes (Timeline, GetDataTableRow, AddComponentByClass, Self, Knot)
+// Header for creating specialized nodes (Timeline, GetDataTableRow, AddComponentByClass, Self, Knot, macros)
 
 #pragma once
 
@@ -52,4 +52,20 @@ public:
 	 * @return The created node or nullptr on error
 	 */
 	static UK2Node* CreateKnotNode(UEdGraph* Graph, const TSharedPtr<class FJsonObject>& Params);
+
+	/**
+	 * Creates a Macro Instance node (K2Node_MacroInstance)
+	 * @param Graph - The graph to add the node to
+	 * @param Params - JSON parameters containing pos_x, pos_y, macro_name and optional macro_blueprint
+	 * @return The created node or nullptr on error
+	 */
+	static UK2Node* CreateMacroInstanceNode(UEdGraph* Graph, const TSharedPtr<class FJsonObject>& Params);
+
+	/**
+	 * Creates an additional Function Result node using the graph's existing result signature.
+	 * @param Graph - The function graph to add the node to
+	 * @param Params - JSON parameters containing pos_x, pos_y
+	 * @return The created node or nullptr on error
+	 */
+	static UK2Node* CreateFunctionResultNode(UEdGraph* Graph, const TSharedPtr<class FJsonObject>& Params);
 };

--- a/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPBlueprintCommands.h
+++ b/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPBlueprintCommands.h
@@ -17,6 +17,8 @@ public:
 private:
     // Specific blueprint command handlers (only used functions)
     TSharedPtr<FJsonObject> HandleCreateBlueprint(const TSharedPtr<FJsonObject>& Params);
+    TSharedPtr<FJsonObject> HandleReparentBlueprint(const TSharedPtr<FJsonObject>& Params);
+    TSharedPtr<FJsonObject> HandleSetWidgetIsVariable(const TSharedPtr<FJsonObject>& Params);
     TSharedPtr<FJsonObject> HandleAddComponentToBlueprint(const TSharedPtr<FJsonObject>& Params);
     TSharedPtr<FJsonObject> HandleSetPhysicsProperties(const TSharedPtr<FJsonObject>& Params);
     TSharedPtr<FJsonObject> HandleCompileBlueprint(const TSharedPtr<FJsonObject>& Params);
@@ -38,4 +40,4 @@ private:
     TSharedPtr<FJsonObject> HandleGetBlueprintFunctionDetails(const TSharedPtr<FJsonObject>& Params);
 
 
-}; 
+};

--- a/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPBlueprintGraphCommands.h
+++ b/UnrealMCP/Source/UnrealMCP/Public/Commands/EpicUnrealMCPBlueprintGraphCommands.h
@@ -23,8 +23,14 @@ private:
     // Add node to Blueprint graph
     TSharedPtr<FJsonObject> HandleAddBlueprintNode(const TSharedPtr<FJsonObject>& Params);
 
+    // Add node to Blueprint graph using a command-level node type alias
+    TSharedPtr<FJsonObject> HandleAddBlueprintNodeAlias(const TSharedPtr<FJsonObject>& Params, const FString& NodeType);
+
     // Connect nodes in Blueprint graph
     TSharedPtr<FJsonObject> HandleConnectNodes(const TSharedPtr<FJsonObject>& Params);
+
+    // Break all links on one Blueprint pin
+    TSharedPtr<FJsonObject> HandleBreakPinLinks(const TSharedPtr<FJsonObject>& Params);
 
     // Create variable in Blueprint
     TSharedPtr<FJsonObject> HandleCreateVariable(const TSharedPtr<FJsonObject>& Params);
@@ -44,6 +50,9 @@ private:
     // Create function in Blueprint
     TSharedPtr<FJsonObject> HandleCreateFunction(const TSharedPtr<FJsonObject>& Params);
 
+    // Create an override function graph in Blueprint
+    TSharedPtr<FJsonObject> HandleCreateOverrideFunction(const TSharedPtr<FJsonObject>& Params);
+
     // Add function input parameter
     TSharedPtr<FJsonObject> HandleAddFunctionInput(const TSharedPtr<FJsonObject>& Params);
 
@@ -55,4 +64,7 @@ private:
 
     // Rename function in Blueprint
     TSharedPtr<FJsonObject> HandleRenameFunction(const TSharedPtr<FJsonObject>& Params);
+
+    // Execute multiple generic Blueprint graph operations in one command
+    TSharedPtr<FJsonObject> HandleBatchGraphCommands(const TSharedPtr<FJsonObject>& Params);
 };

--- a/UnrealMCP/Source/UnrealMCP/UnrealMCP.Build.cs
+++ b/UnrealMCP/Source/UnrealMCP/UnrealMCP.Build.cs
@@ -34,6 +34,7 @@ public class UnrealMCP : ModuleRules
 				"Core",
 				"CoreUObject",
 				"Engine",
+				"EnhancedInput",
 				"InputCore",
 				"Networking",
 				"Sockets",
@@ -56,6 +57,7 @@ public class UnrealMCP : ModuleRules
 				"Slate",
 				"SlateCore",
 				"Kismet",
+				"UMG",
 				"Projects",
 				"AssetRegistry"
 			}
@@ -68,7 +70,9 @@ public class UnrealMCP : ModuleRules
 				{
 					"PropertyEditor",      // For property editing
 					"ToolMenus",           // For editor UI
-					"BlueprintEditorLibrary" // For Blueprint utilities
+					"BlueprintEditorLibrary", // For Blueprint utilities
+					"InputBlueprintNodes", // For Enhanced Input action event nodes
+					"UMGEditor"            // For WidgetBlueprint authoring
 				}
 			);
 		}
@@ -80,4 +84,4 @@ public class UnrealMCP : ModuleRules
 			}
 		);
 	}
-} 
+}

--- a/UnrealMCP/UnrealMCP.uplugin
+++ b/UnrealMCP/UnrealMCP.uplugin
@@ -30,6 +30,10 @@
 		{
 			"Name": "EditorScriptingUtilities",
 			"Enabled": true
+		},
+		{
+			"Name": "EnhancedInput",
+			"Enabled": true
 		}
 	]
-} 
+}


### PR DESCRIPTION
﻿## Summary

Adds a broader Blueprint graph authoring surface to the Unreal MCP plugin so external MCP clients can build and repair visible Blueprint graphs instead of falling back to manual editor work.

This keeps the standalone `UnrealMCP` plugin copy and the `FlopperamUnrealMCP/Plugins/UnrealMCP` copy in sync.

## What's included

- Adds command routing for additional Blueprint graph operations:
  - `break_pin_links`
  - `create_override_function`
  - `execute_blueprint_graph_batch` / `batch_blueprint_graph_commands`
  - macro aliases such as for-loop / foreach-loop / while-loop nodes
  - `reparent_blueprint`
  - `set_widget_is_variable`
- Expands node creation support for graph-only Blueprint authoring:
  - struct nodes: make, break, set fields / set members
  - array nodes: array get and array function calls
  - enhanced input action event nodes
  - construct object, function result, macro instance and additional utility nodes
- Expands Blueprint variable typing for graph work:
  - `text`, `name`, `byte`, `vector2d`, `intpoint`
  - enum, struct, object and class path-backed types
  - array types via `array:<type>`
- Improves graph operations and inspection:
  - function graph-aware connect/delete/property operations
  - pin default/object/text reporting in graph analysis
  - wildcard/link handling improvements in connector code
  - safer compile/save behavior for generated Blueprints
- Improves TCP command handling for large graph batches by buffering partial JSON commands instead of treating every partial receive as invalid JSON.
- Adds required module/plugin dependencies for UMG and Enhanced Input graph authoring.

## Validation

- Applied the same patch to both plugin copies and verified the changed files are byte-identical between `UnrealMCP` and `FlopperamUnrealMCP/Plugins/UnrealMCP`.
- Ran `git diff --check` successfully.
- The source changes came from a UE project session where the new commands were used to create variables, add/connect Blueprint graph nodes, break pin links, create override functions, compile/save Blueprints, and inspect graph pins while building a graph-only UMG inventory workflow.

A full Unreal Engine rebuild is not included here because this PR checkout is a source mirror without a project build invocation.
